### PR TITLE
Tycho build gefixt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>aero.minova.rcp</groupId>
 		<artifactId>aero.minova.rcp.configuration</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1-SNAPSHOT</version>
 		<relativePath>./releng/aero.minova.rcp.configuration</relativePath>
 	</parent>
 	<!-- end::parent[] -->

--- a/releng/aero.minova.rcp.configuration/pom.xml
+++ b/releng/aero.minova.rcp.configuration/pom.xml
@@ -6,7 +6,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho.version>1.4.0</tycho.version>
+		<tycho.version>1.5.0</tycho.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/2018-12</eclipse-repo.url>
 	</properties>
@@ -63,7 +63,7 @@
 						<artifact>
 							<groupId>aero.minova.rcp</groupId>
 							<artifactId>eclipse-2019-03</artifactId>
-							<version>1.0.0</version>
+							<version>1.0.1-SNAPSHOT</version>
 						</artifact>
 					</target>
 					<!-- end::target-definition[] -->

--- a/releng/target-definition/pom.xml
+++ b/releng/target-definition/pom.xml
@@ -1,58 +1,23 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	
+	
+	 <parent>
+    	<groupId>aero.minova.rcp</groupId>
+ 		<artifactId>aero.minova.rcp.releng</artifactId>
+    	<version>1.2.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    
+	
 	<groupId>aero.minova.rcp</groupId>
 	<artifactId>eclipse-2019-03</artifactId>
 	<version>1.0.1-SNAPSHOT</version>
 	<packaging>eclipse-target-definition</packaging>
+	
+	
 
-	<properties>
-		<tycho.version>1.5.0</tycho.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<eclipse-repo.url>http://download.eclipse.org/releases/2018-12</eclipse-repo.url>
-	</properties>
+   
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-maven-plugin</artifactId>
-				<version>${tycho.version}</version>
-				<extensions>true</extensions>
-			</plugin>
-			<!--Enable the replacement of the SNAPSHOT version in the final product configuration -->
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-packaging-plugin</artifactId>
-				<version>${tycho.version}</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<id>package-feature</id>
-						<configuration>
-							<finalName>${project.artifactId}_${unqualifiedVersion}.${buildQualifier}</finalName>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 
-	<distributionManagement>
-		<repository>
-			<id>nexus</id>
-			<name>Internal Releases</name>
-			<url>http://nexus.minova.com:8081/nexus/content/repositories/releases/</url>
-		</repository>
-		<snapshotRepository>
-			<id>nexus</id>
-			<name>Internal Snapshots</name>
-			<url>http://nexus.minova.com:8081/nexus/content/repositories/snapshots/</url>
-		</snapshotRepository>
-	</distributionManagement>
-
-	<scm>
-		<connection>scm:git:https://github.com/minova-afis/aero.minova.rcp.git</connection>
-		<developerConnection>scm:git:https://github.com/minova-afis/aero.minova.rcp.git</developerConnection>
-		<tag>HEAD</tag>
-	</scm>
 </project>


### PR DESCRIPTION
- Versionsreference in root pom auf configuration pom war falsch
- Verschiedene Tycho versionen (1.4 und 1.5) können nicht in einem Build
verwendet werden
- Target definitions pom sollte eine Referenz auf das Konfigurations pom
haben