### PR TITLE
CasCommunicationTest wird ignoriert vom Build

### DIFF
--- a/tests/aero.minova.rcp.xml.tests/pom.xml
+++ b/tests/aero.minova.rcp.xml.tests/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+http://maven.apache.org/maven-v4_0_0.xsd">
+<modelVersion>4.0.0</modelVersion>
+	<groupId>aero.minova.rcp</groupId>
+	<artifactId>aero.minova.rcp.xml.tests</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>eclipse-test-plugin</packaging>
+	<parent>
+		<groupId>aero.minova.rcp</groupId>
+		<artifactId>aero.minova.rcp.tests</artifactId>
+		<version>1.2.0-SNAPSHOT</version>
+	</parent>
+	<build>
+		<plugins>
+
+		<plugin>
+		 <groupId>org.eclipse.tycho</groupId>
+		 <artifactId>tycho-surefire-plugin</artifactId>
+		 <version>${tycho.version}</version>
+			<configuration>
+				<excludes>
+          			<!-- Tests trying to access the server-->
+          			<exclude>CasCommunicationTest</exclude>
+          			<exclude>XmlReaderTests</exclude>
+				</excludes>
+			</configuration>
+		</plugin>
+		</plugins>
+	</build>	
+</project>


### PR DESCRIPTION
CasCommunicationTest funktioniert nicht von Github aus.
XmlReaderTests muss noch angepasst werden, aktuell auch auskommmentiert.