### PR TITLE
Nattable work

### DIFF
--- a/bundles/aero.minova.rcp.rcp/Application.e4xmi
+++ b/bundles/aero.minova.rcp.rcp/Application.e4xmi
@@ -1,71 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <application:Application xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:advanced="http://www.eclipse.org/ui/2010/UIModel/application/ui/advanced" xmlns:application="http://www.eclipse.org/ui/2010/UIModel/application" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmlns:menu="http://www.eclipse.org/ui/2010/UIModel/application/ui/menu" xmi:id="_6wlLcMgZEeSyMNYR5xypkQ" elementId="aero.minova.rcp.rcp.application" bindingContexts="_6wlLecgZEeSyMNYR5xypkQ">
   <children xsi:type="basic:TrimmedWindow" xmi:id="_6wlLccgZEeSyMNYR5xypkQ" elementId="aero.minova.rcp.rcp.window.main" label="Eclipse 4 RCP Application" bindingContexts="_6wlLesgZEeSyMNYR5xypkQ" width="1024" height="800">
-    <children xsi:type="advanced:PerspectiveStack" xmi:id="_zNk5ALYjEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.perspectivestack">
-      <children xsi:type="advanced:Perspective" xmi:id="_zkeWELYjEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.perspective.sis" label="SIS">
-        <children xsi:type="basic:PartSashContainer" xmi:id="_a8dzoLYlEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.partsashcontainer.main" horizontal="true">
-          <children xsi:type="basic:PartSashContainer" xmi:id="_Blgn4LYkEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.partsashcontainer.1" containerData="1000">
-            <children xsi:type="basic:PartStack" xmi:id="_DgwT4LblEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.partstack.search" selectedElement="_C4Nl4LYkEeqEVOzPNoSbhw">
-              <children xsi:type="basic:Part" xmi:id="_C4Nl4LYkEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.part.search" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.parts.WFCSearchPart" label="@Form.Search" tooltip="Hier kann man Sachen machen. ">
-                <handlers xmi:id="_6jvuwNDREeqZdekMGDv2pg" elementId="aero.minova.rcp.rcp.handler.revertsearch" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.RevertSearchHandler" command="_y3TngNDREeqZdekMGDv2pg"/>
-                <handlers xmi:id="_GOfCINDTEeqZdekMGDv2pg" elementId="aero.minova.rcp.rcp.handler.clearsearch" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.ClearSearchHandler" command="_rnXZkNDSEeqZdekMGDv2pg"/>
-                <handlers xmi:id="_GZafwNDTEeqZdekMGDv2pg" elementId="aero.minova.rcp.rcp.handler.optimizesearch" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.OptimizeSearchHandler" command="_sJJQ8NDSEeqZdekMGDv2pg"/>
-                <handlers xmi:id="_GTuugNDTEeqZdekMGDv2pg" elementId="aero.minova.rcp.rcp.handler.loadsearchcriteria" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.LoadSearchCriteriaHandler" command="_r5Qa0NDSEeqZdekMGDv2pg"/>
-                <handlers xmi:id="_GWvmQNDTEeqZdekMGDv2pg" elementId="aero.minova.rcp.rcp.handler.savesearchcriteria" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.SaveSearchCriteriaHandler" command="_sAqqYNDSEeqZdekMGDv2pg"/>
-                <toolbar xmi:id="_pvc5ALbkEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.toolbar.1">
-                  <tags>NoMove</tags>
-                  <children xsi:type="menu:HandledToolItem" xmi:id="_rX_kILbkEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.revert" label="Revert" command="_y3TngNDREeqZdekMGDv2pg"/>
-                  <children xsi:type="menu:HandledToolItem" xmi:id="_vUnxwLbkEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.clear" label="Clear" command="_rnXZkNDSEeqZdekMGDv2pg"/>
-                  <children xsi:type="menu:HandledToolItem" xmi:id="_0xNWQLbkEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.save" label="Save" command="_sAqqYNDSEeqZdekMGDv2pg"/>
-                  <children xsi:type="menu:HandledToolItem" xmi:id="_yd5P0LbkEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.load" label="Load" command="_r5Qa0NDSEeqZdekMGDv2pg"/>
-                  <children xsi:type="menu:HandledToolItem" xmi:id="_2CU_4LbkEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.optimize" label="Optimize" command="_sJJQ8NDSEeqZdekMGDv2pg"/>
-                </toolbar>
-              </children>
-            </children>
-            <children xsi:type="basic:PartStack" xmi:id="_kj92ILblEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.partstack.2">
-              <children xsi:type="basic:Part" xmi:id="_VXUwELYlEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.part.index" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.parts.WFCIndexPart" label="@Form.Index">
-                <handlers xmi:id="_0qEZAOejEeq-Csq7J9vXlA" elementId="aero.minova.rcp.rcp.handler.loadindex" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.LoadIndexHandler" command="_xHFacOejEeq-Csq7J9vXlA"/>
-                <handlers xmi:id="_YyA_sOg1Eeq4vM3bKRf1IQ" elementId="aero.minova.rcp.rcp.handler.expandindex" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.ExpandIndexHandler" command="_Mt6KEOg0Eeq4vM3bKRf1IQ"/>
-                <handlers xmi:id="_fnbYUOg1Eeq4vM3bKRf1IQ" elementId="aero.minova.rcp.rcp.handler.collapseindex" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.CollapseIndexHandler" command="_ZtzH8Og0Eeq4vM3bKRf1IQ"/>
-                <handlers xmi:id="_jofaAOg1Eeq4vM3bKRf1IQ" elementId="aero.minova.rcp.rcp.handler.exportindex" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.ExportIndexHandler" command="_c0UM8Og0Eeq4vM3bKRf1IQ"/>
-                <handlers xmi:id="_nStB8Og1Eeq4vM3bKRf1IQ" elementId="aero.minova.rcp.rcp.handler.printindex" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.PrintIndexHandler" command="_ks22gOg0Eeq4vM3bKRf1IQ"/>
-                <handlers xmi:id="_q4Z9UOg1Eeq4vM3bKRf1IQ" elementId="aero.minova.rcp.rcp.handler.resizeindex" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.ResizeIndexHandler" command="_oYW34Og0Eeq4vM3bKRf1IQ"/>
-                <toolbar xmi:id="_xQqyQLblEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.toolbar.0">
-                  <children xsi:type="menu:HandledToolItem" xmi:id="_0MXuYLblEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.load" label="Load" command="_xHFacOejEeq-Csq7J9vXlA"/>
-                  <children xsi:type="menu:HandledToolItem" xmi:id="_1xOzYLblEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.expand" label="Expand" command="_Mt6KEOg0Eeq4vM3bKRf1IQ"/>
-                  <children xsi:type="menu:HandledToolItem" xmi:id="_8zFFgLblEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.collapse" label="Collapse" command="_ZtzH8Og0Eeq4vM3bKRf1IQ"/>
-                  <children xsi:type="menu:HandledToolItem" xmi:id="_-JVt0LblEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.exportindex" label="ExportIndex" command="_c0UM8Og0Eeq4vM3bKRf1IQ"/>
-                  <children xsi:type="menu:HandledToolItem" xmi:id="_Ah_nQLbmEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.print" label="Print" command="_ks22gOg0Eeq4vM3bKRf1IQ"/>
-                  <children xsi:type="menu:HandledToolItem" xmi:id="_D1f_YLbmEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.resize" label="Resize" command="_oYW34Og0Eeq4vM3bKRf1IQ"/>
-                </toolbar>
-              </children>
-            </children>
-          </children>
-          <children xsi:type="basic:PartStack" xmi:id="_XDJgALbmEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.partstack.detail" containerData="1000">
-            <children xsi:type="basic:Part" xmi:id="_bwZyALYlEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.part.detail" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.parts.WFCDetailPart" label="@Form.Detail">
-              <handlers xmi:id="_1C18wAMrEeuqN4GJQN2E0w" elementId="aero.minova.rcp.rcp.handler.savedetail" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.SaveDetailHandler" command="_2hwmEOg1Eeq4vM3bKRf1IQ"/>
-              <handlers xmi:id="_rItNsOg2Eeq4vM3bKRf1IQ" elementId="aero.minova.rcp.rcp.handler.newdetail" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.NewDetailHandler" command="_5ODNMOg1Eeq4vM3bKRf1IQ"/>
-              <handlers xmi:id="_ul67cOg2Eeq4vM3bKRf1IQ" elementId="aero.minova.rcp.rcp.handler.deletedetail" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.DeleteDetailHandler" command="_7pSgkOg1Eeq4vM3bKRf1IQ"/>
-              <handlers xmi:id="_yOGjEOg2Eeq4vM3bKRf1IQ" elementId="aero.minova.rcp.rcp.handler.revertdetail" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.RevertDetailHandler" command="_9_ZcUOg1Eeq4vM3bKRf1IQ"/>
-              <handlers xmi:id="_5pKmcOg2Eeq4vM3bKRf1IQ" elementId="aero.minova.rcp.rcp.handler.printdetail" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.PrintDetailHandler" command="_Awo04Og2Eeq4vM3bKRf1IQ"/>
-              <handlers xmi:id="_0VNTQNWPEeq9oeSITNqxdw" elementId="aero.minova.rcp.rcp.handler.optimizedetail" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.handlers.OptimizeDetailHandler" command="_wuFbkNWPEeq9oeSITNqxdw"/>
-              <toolbar xmi:id="_ep_8oLbmEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.toolbar.2">
-                <tags>NoMove</tags>
-                <children xsi:type="menu:HandledToolItem" xmi:id="_oh6ssLbVEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.save" label="Save" iconURI="platform:/plugin/aero.minova.rcp.rcp/icons/save_edit.png" command="_2hwmEOg1Eeq4vM3bKRf1IQ"/>
-                <children xsi:type="menu:HandledToolItem" xmi:id="_z_Hv0LbVEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.new" label="New" iconURI="platform:/plugin/aero.minova.rcp.rcp/icons/new.png" command="_5ODNMOg1Eeq4vM3bKRf1IQ"/>
-                <children xsi:type="menu:HandledToolItem" xmi:id="_9wjNoLbVEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.delete" label="Delete" command="_7pSgkOg1Eeq4vM3bKRf1IQ"/>
-                <children xsi:type="menu:HandledToolItem" xmi:id="_BqzcsLbWEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.revert" label="Revert" command="_9_ZcUOg1Eeq4vM3bKRf1IQ"/>
-                <children xsi:type="menu:HandledToolItem" xmi:id="_X4AesLbWEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.booking" visible="false" label="Booking"/>
-                <children xsi:type="menu:HandledToolItem" xmi:id="_fyN8MLbWEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.cancel" visible="false" label="Cancel"/>
-                <children xsi:type="menu:HandledToolItem" xmi:id="_kDdu8LbWEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.correct" visible="false" label="Correct"/>
-                <children xsi:type="menu:HandledToolItem" xmi:id="_wqWW8LbWEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.print" label="Print" type="Radio"/>
-                <children xsi:type="menu:HandledToolItem" xmi:id="_r8lAQLbWEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.handledtoolitem.optimize" label="Optimize" command="_wuFbkNWPEeq9oeSITNqxdw"/>
-              </toolbar>
-            </children>
-          </children>
-        </children>
-      </children>
-    </children>
+    <children xsi:type="advanced:PerspectiveStack" xmi:id="_zNk5ALYjEeqEVOzPNoSbhw" elementId="aero.minova.rcp.rcp.perspectivestack"/>
     <snippets xsi:type="advanced:Perspective" xmi:id="_G_59ALqjEeqSa5ZfLepYaA" elementId="aero.minova.rcp.rcp.perspective.main" selectedElement="_RRPC4LqjEeqSa5ZfLepYaA" label="Snippet">
       <children xsi:type="basic:PartSashContainer" xmi:id="_RRPC4LqjEeqSa5ZfLepYaA" elementId="aero.minova.rcp.rcp.partsashcontainer.main" selectedElement="_S7uOwLqjEeqSa5ZfLepYaA" horizontal="true">
         <children xsi:type="basic:PartSashContainer" xmi:id="_S7uOwLqjEeqSa5ZfLepYaA" elementId="aero.minova.rcp.rcp.partsashcontainer.left" selectedElement="_ZHU1YLqjEeqSa5ZfLepYaA">

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/nattable/MinovaEditConfiguration.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/nattable/MinovaEditConfiguration.java
@@ -11,6 +11,7 @@ import org.eclipse.nebula.widgets.nattable.data.convert.DefaultBooleanDisplayCon
 import org.eclipse.nebula.widgets.nattable.data.convert.DefaultDoubleDisplayConverter;
 import org.eclipse.nebula.widgets.nattable.edit.EditConfigAttributes;
 import org.eclipse.nebula.widgets.nattable.edit.editor.CheckBoxCellEditor;
+import org.eclipse.nebula.widgets.nattable.edit.editor.EditorSelectionEnum;
 import org.eclipse.nebula.widgets.nattable.edit.editor.TextCellEditor;
 import org.eclipse.nebula.widgets.nattable.layer.cell.ColumnLabelAccumulator;
 import org.eclipse.nebula.widgets.nattable.painter.cell.CheckBoxPainter;
@@ -52,7 +53,9 @@ public class MinovaEditConfiguration extends AbstractRegistryConfiguration {
 	private void registerTextEditor(IConfigRegistry configRegistry, int columnIndex) {
 		// register a TextCellEditor for column two that commits on key up/down
 		// moves the selection after commit by enter
-		configRegistry.registerConfigAttribute(EditConfigAttributes.CELL_EDITOR, new TextCellEditor(true, true),
+		TextCellEditor attributeValue = new TextCellEditor(true, true);
+		attributeValue.setSelectionMode(EditorSelectionEnum.START);
+		configRegistry.registerConfigAttribute(EditConfigAttributes.CELL_EDITOR, attributeValue,
 				DisplayMode.NORMAL, ColumnLabelAccumulator.COLUMN_LABEL_PREFIX + columnIndex);
 
 		// configure to open the adjacent editor after commit

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/nattable/NatTableSearchPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/nattable/NatTableSearchPart.java
@@ -1,0 +1,257 @@
+package aero.minova.rcp.rcp.nattable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.nebula.widgets.nattable.NatTable;
+import org.eclipse.nebula.widgets.nattable.config.ConfigRegistry;
+import org.eclipse.nebula.widgets.nattable.config.DefaultNatTableStyleConfiguration;
+import org.eclipse.nebula.widgets.nattable.data.IColumnPropertyAccessor;
+import org.eclipse.nebula.widgets.nattable.data.IDataProvider;
+import org.eclipse.nebula.widgets.nattable.data.ListDataProvider;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.GlazedListsSortModel;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.groupBy.GroupByHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.groupBy.GroupByHeaderMenuConfiguration;
+import org.eclipse.nebula.widgets.nattable.grid.GridRegion;
+import org.eclipse.nebula.widgets.nattable.grid.data.DefaultColumnHeaderDataProvider;
+import org.eclipse.nebula.widgets.nattable.grid.data.DefaultCornerDataProvider;
+import org.eclipse.nebula.widgets.nattable.grid.data.DefaultRowHeaderDataProvider;
+import org.eclipse.nebula.widgets.nattable.grid.layer.ColumnHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.CornerLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.DefaultColumnHeaderDataLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.DefaultRowHeaderDataLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.GridLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.RowHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.layer.CompositeLayer;
+import org.eclipse.nebula.widgets.nattable.layer.DataLayer;
+import org.eclipse.nebula.widgets.nattable.layer.ILayer;
+import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer;
+import org.eclipse.nebula.widgets.nattable.selection.config.DefaultRowSelectionLayerConfiguration;
+import org.eclipse.nebula.widgets.nattable.sort.SortHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.sort.config.SingleClickSortConfiguration;
+import org.eclipse.nebula.widgets.nattable.tree.config.TreeLayerExpandCollapseKeyBindings;
+import org.eclipse.nebula.widgets.nattable.viewport.ViewportLayer;
+import org.eclipse.swt.widgets.Composite;
+
+import aero.minova.rcp.form.model.xsd.Column;
+import aero.minova.rcp.form.model.xsd.Form;
+import aero.minova.rcp.model.Row;
+import aero.minova.rcp.model.Table;
+import aero.minova.rcp.nattable.data.MinovaColumnPropertyAccessor;
+import aero.minova.rcp.rcp.nattable.NatTableWrapper.BodyLayerStack;
+import ca.odell.glazedlists.EventList;
+import ca.odell.glazedlists.GlazedLists;
+import ca.odell.glazedlists.SortedList;
+
+public class NatTableSearchPart {
+
+	private NatTable natTable;
+	private BodyLayerStack<Row> bodyLayerStack;
+	private IEclipseContext context;
+
+	public void createNatTable(Composite parent, Form form, Table table) {
+
+		Map<String, String> tableHeadersMap = new HashMap<>();
+		List<Column> columns = form.getIndexView().getColumn();
+		String[] propertyNames = new String[columns.size()];
+		int i = 0;
+		for (Column column : columns) {
+			tableHeadersMap.put(column.getName(), column.getLabel());
+			propertyNames[i++] = column.getName();
+		}
+
+		// Datenmodel für die Eingaben
+		ConfigRegistry configRegistry = new ConfigRegistry();
+		IColumnPropertyAccessor<Row> columnPropertyAccessor = new MinovaColumnPropertyAccessor(table);
+
+		
+		// create the body stack
+		EventList<Row> eventList = GlazedLists.eventList(table.getRows());
+		SortedList<Row> sortedList = new SortedList<>(eventList, null);
+		
+		IDataProvider bodyDataProvider = new ListDataProvider<Row>(sortedList, columnPropertyAccessor);
+		
+		DataLayer bodyDataLayer = new DataLayer(bodyDataProvider);
+		// selection layer
+		SelectionLayer selectionLayer = new SelectionLayer(bodyDataLayer);
+		// Enable full selection for rows
+		selectionLayer.addConfiguration(new DefaultRowSelectionLayerConfiguration());
+		
+		//view port layer
+		ViewportLayer viewportLayer = new ViewportLayer(selectionLayer);
+
+		// as the selection mouse bindings are registered for the region label
+		// GridRegion.BODY
+		// we need to set that region label to the viewport so the selection via mouse
+		// is working correctly
+		viewportLayer.setRegionName(GridRegion.BODY);
+		
+
+		// build the column header layer
+		IDataProvider columnHeaderDataProvider = new DefaultColumnHeaderDataProvider(propertyNames, tableHeadersMap);
+		DataLayer columnHeaderDataLayer = new DefaultColumnHeaderDataLayer(columnHeaderDataProvider);
+		ColumnHeaderLayer columnHeaderLayer = new ColumnHeaderLayer(columnHeaderDataLayer,
+				bodyLayerStack,
+				bodyLayerStack.getSelectionLayer());
+
+		SortHeaderLayer<Row> sortHeaderLayer = new SortHeaderLayer<>(columnHeaderLayer,
+				new GlazedListsSortModel<>(bodyLayerStack.getSortedList(), columnPropertyAccessor, configRegistry,
+						columnHeaderDataLayer));
+
+		// build the row header layer
+		IDataProvider rowHeaderDataProvider = new DefaultRowHeaderDataProvider(bodyLayerStack.getBodyDataProvider());
+		DataLayer rowHeaderDataLayer = new DefaultRowHeaderDataLayer(rowHeaderDataProvider);
+		ILayer rowHeaderLayer = new RowHeaderLayer(rowHeaderDataLayer, bodyLayerStack,
+				bodyLayerStack.getSelectionLayer());
+
+		// build the corner layer
+		IDataProvider cornerDataProvider = new DefaultCornerDataProvider(columnHeaderDataProvider,
+				rowHeaderDataProvider);
+		DataLayer cornerDataLayer = new DataLayer(cornerDataProvider);
+		ILayer cornerLayer = new CornerLayer(cornerDataLayer, rowHeaderLayer, columnHeaderLayer);
+
+		// build the grid layer
+		GridLayer gridLayer = new GridLayer(viewportLayer, sortHeaderLayer, rowHeaderLayer, cornerLayer);
+
+		// set the group by header on top of the grid
+		CompositeLayer compositeGridLayer = new CompositeLayer(1, 2);
+		final GroupByHeaderLayer groupByHeaderLayer = new GroupByHeaderLayer(bodyLayerStack.getGroupByModel(),
+				gridLayer, columnHeaderDataProvider, columnHeaderLayer);
+		compositeGridLayer.setChildLayer(GroupByHeaderLayer.GROUP_BY_REGION, groupByHeaderLayer, 0, 0);
+		compositeGridLayer.setChildLayer("Grid", gridLayer, 0, 1);
+
+		natTable = new NatTable(parent, compositeGridLayer, false);
+
+
+
+		// as the autoconfiguration of the NatTable is turned off, we have to
+		// add the DefaultNatTableStyleConfiguration and the ConfigRegistry
+		// manually
+		natTable.setConfigRegistry(configRegistry);
+		natTable.addConfiguration(new DefaultNatTableStyleConfiguration());
+		natTable.addConfiguration(new SingleClickSortConfiguration());
+//		natTable.registerCommandHandler(new DisplayPersistenceDialogCommandHandler(natTable));
+//
+//		// add group by configuration
+		natTable.addConfiguration(new GroupByHeaderMenuConfiguration(natTable, groupByHeaderLayer));
+		// adds the key bindings that allow space bar to be pressed to
+        // expand/collapse tree nodes
+		natTable.addConfiguration(new TreeLayerExpandCollapseKeyBindings(bodyLayerStack.getTreeLayer(),
+				bodyLayerStack.getSelectionLayer()));
+		// natTable.addConfiguration(new HeaderMenuConfiguration(natTable) {
+//			@Override
+//			protected PopupMenuBuilder createCornerMenu(NatTable natTable) {
+//				return super.createCornerMenu(natTable).withStateManagerMenuItemProvider()
+//						.withMenuItemProvider(new IMenuItemProvider() {
+//
+//							@Override
+//							public void addMenuItem(NatTable natTable, Menu popupMenu) {
+//								MenuItem menuItem = new MenuItem(popupMenu, SWT.PUSH);
+//								menuItem.setText("Toggle Group By Header"); //$NON-NLS-1$
+//								menuItem.setEnabled(true);
+//
+//								menuItem.addSelectionL	istener(new SelectionAdapter() {
+//									@Override
+//									public void widgetSelected(SelectionEvent event) {
+//										groupByHeaderLayer.setVisible(!groupByHeaderLayer.isVisible());
+//									}
+//								});
+//							}
+//						}).withMenuItemProvider(new IMenuItemProvider() {
+//
+//							@Override
+//							public void addMenuItem(final NatTable natTable, Menu popupMenu) {
+//								MenuItem menuItem = new MenuItem(popupMenu, SWT.PUSH);
+//								menuItem.setText("Collapse All"); //$NON-NLS-1$
+//								menuItem.setEnabled(true);
+//
+//								menuItem.addSelectionListener(new SelectionAdapter() {
+//									@Override
+//									public void widgetSelected(SelectionEvent event) {
+//										natTable.doCommand(new TreeCollapseAllCommand());
+//									}
+//								});
+//							}
+//						}).withMenuItemProvider(new IMenuItemProvider() {
+//
+//							@Override
+//							public void addMenuItem(final NatTable natTable, Menu popupMenu) {
+//								MenuItem menuItem = new MenuItem(popupMenu, SWT.PUSH);
+//								menuItem.setText("Expand All"); //$NON-NLS-1$
+//								menuItem.setEnabled(true);
+//
+//								menuItem.addSelectionListener(new SelectionAdapter() {
+//									@Override
+//									public void widgetSelected(SelectionEvent event) {
+//										natTable.doCommand(new TreeExpandAllCommand());
+//									}
+//								});
+//							}
+//						}).withMenuItemProvider(new IMenuItemProvider() {
+//
+//							@Override
+//							public void addMenuItem(final NatTable natTable, Menu popupMenu) {
+//								MenuItem menuItem = new MenuItem(popupMenu, SWT.PUSH);
+//								menuItem.setText("Expand to Level 2"); //$NON-NLS-1$
+//								menuItem.setEnabled(true);
+//
+//								menuItem.addSelectionListener(new SelectionAdapter() {
+//									@Override
+//									public void widgetSelected(SelectionEvent event) {
+//										natTable.doCommand(new TreeExpandToLevelCommand(2));
+//									}
+//								});
+//							}
+//						});
+//			}
+//		});
+//
+
+
+		natTable.addConfiguration(new MinovaEditConfiguration(table.getColumns()));
+
+		natTable.setLayoutData(GridDataFactory.fillDefaults().grab(true, true).create());
+//		
+
+//		DataLayer bodyDataLayer = new DataLayer(bodyDataProvider);
+//
+//		SelectionLayer selectionLayer = new SelectionLayer(bodyDataLayer);
+//		ViewportLayer viewportLayer = new ViewportLayer(selectionLayer);
+//
+//		IDataProvider columnHeaderDataProvider = new DefaultColumnHeaderDataProvider(
+//				propertyNames,propertyToLabelMap);
+//		DataLayer columnHeaderDataLayer = new DefaultColumnHeaderDataLayer(columnHeaderDataProvider);
+//		ILayer columnHeaderLayer = new ColumnHeaderLayer(columnHeaderDataLayer, viewportLayer, selectionLayer);
+//
+//		SortHeaderLayer<Person> sortHeaderLayer = new SortHeaderLayer<>(columnHeaderLayer,
+//				new GlazedListsSortModel<>(sortedList, accessor, configRegistry, columnHeaderDataLayer));
+//
+//		CompositeLayer compositeLayer = new CompositeLayer(1, 2);
+//		compositeLayer.setChildLayer(GridRegion.COLUMN_HEADER, sortHeaderLayer, 0, 0);
+//		compositeLayer.setChildLayer(GridRegion.BODY, viewportLayer, 0, 1);
+
+//		NatTable natTable = new NatTable(parent, compositeLayer, false);
+//
+//		natTable.setConfigRegistry(configRegistry);
+//		natTable.addConfiguration(new DefaultNatTableStyleConfiguration());
+		natTable.addConfiguration(new SingleClickSortConfiguration());
+
+		natTable.configure();
+		// set the modern theme to visualize the summary better
+
+//		ThemeConfiguration modernTheme = new ModernNatTableThemeConfiguration();
+//		modernTheme.addThemeExtension(new ModernGroupByThemeExtension());
+//
+//		natTable.setTheme(modernTheme);
+
+
+	}
+
+	public void updateData(List<Row> list) {
+//		bodyLayerStack.getSortedList().clear();
+//		bodyLayerStack.getSortedList().addAll(list);
+	}
+}

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/nattable/NatTableWrapper.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/nattable/NatTableWrapper.java
@@ -61,7 +61,7 @@ public class NatTableWrapper {
 	private BodyLayerStack<Row> bodyLayerStack;
 	private IEclipseContext context;
 
-	public NatTableWrapper createNatTable(Composite parent, Form form, Table table, Boolean groupByLayer,
+	public NatTable createNatTable(Composite parent, Form form, Table table,
 			ESelectionService selectionService, IEclipseContext context) {
 
 		this.context = context;
@@ -110,7 +110,7 @@ public class NatTableWrapper {
 
 		// set the group by header on top of the grid
 		CompositeLayer compositeGridLayer = new CompositeLayer(1, 2);
-		final GroupByHeaderLayer groupByHeaderLayer = new GroupByHeaderLayer(bodyLayerStack.getGroupByModel(),
+		GroupByHeaderLayer groupByHeaderLayer = new GroupByHeaderLayer(bodyLayerStack.getGroupByModel(),
 				gridLayer, columnHeaderDataProvider, columnHeaderLayer);
 		compositeGridLayer.setChildLayer(GroupByHeaderLayer.GROUP_BY_REGION, groupByHeaderLayer, 0, 0);
 		compositeGridLayer.setChildLayer("Grid", gridLayer, 0, 1);
@@ -133,113 +133,12 @@ public class NatTableWrapper {
         // expand/collapse tree nodes
 		natTable.addConfiguration(new TreeLayerExpandCollapseKeyBindings(bodyLayerStack.getTreeLayer(),
 				bodyLayerStack.getSelectionLayer()));
-		// natTable.addConfiguration(new HeaderMenuConfiguration(natTable) {
-//			@Override
-//			protected PopupMenuBuilder createCornerMenu(NatTable natTable) {
-//				return super.createCornerMenu(natTable).withStateManagerMenuItemProvider()
-//						.withMenuItemProvider(new IMenuItemProvider() {
-//
-//							@Override
-//							public void addMenuItem(NatTable natTable, Menu popupMenu) {
-//								MenuItem menuItem = new MenuItem(popupMenu, SWT.PUSH);
-//								menuItem.setText("Toggle Group By Header"); //$NON-NLS-1$
-//								menuItem.setEnabled(true);
-//
-//								menuItem.addSelectionL	istener(new SelectionAdapter() {
-//									@Override
-//									public void widgetSelected(SelectionEvent event) {
-//										groupByHeaderLayer.setVisible(!groupByHeaderLayer.isVisible());
-//									}
-//								});
-//							}
-//						}).withMenuItemProvider(new IMenuItemProvider() {
-//
-//							@Override
-//							public void addMenuItem(final NatTable natTable, Menu popupMenu) {
-//								MenuItem menuItem = new MenuItem(popupMenu, SWT.PUSH);
-//								menuItem.setText("Collapse All"); //$NON-NLS-1$
-//								menuItem.setEnabled(true);
-//
-//								menuItem.addSelectionListener(new SelectionAdapter() {
-//									@Override
-//									public void widgetSelected(SelectionEvent event) {
-//										natTable.doCommand(new TreeCollapseAllCommand());
-//									}
-//								});
-//							}
-//						}).withMenuItemProvider(new IMenuItemProvider() {
-//
-//							@Override
-//							public void addMenuItem(final NatTable natTable, Menu popupMenu) {
-//								MenuItem menuItem = new MenuItem(popupMenu, SWT.PUSH);
-//								menuItem.setText("Expand All"); //$NON-NLS-1$
-//								menuItem.setEnabled(true);
-//
-//								menuItem.addSelectionListener(new SelectionAdapter() {
-//									@Override
-//									public void widgetSelected(SelectionEvent event) {
-//										natTable.doCommand(new TreeExpandAllCommand());
-//									}
-//								});
-//							}
-//						}).withMenuItemProvider(new IMenuItemProvider() {
-//
-//							@Override
-//							public void addMenuItem(final NatTable natTable, Menu popupMenu) {
-//								MenuItem menuItem = new MenuItem(popupMenu, SWT.PUSH);
-//								menuItem.setText("Expand to Level 2"); //$NON-NLS-1$
-//								menuItem.setEnabled(true);
-//
-//								menuItem.addSelectionListener(new SelectionAdapter() {
-//									@Override
-//									public void widgetSelected(SelectionEvent event) {
-//										natTable.doCommand(new TreeExpandToLevelCommand(2));
-//									}
-//								});
-//							}
-//						});
-//			}
-//		});
-//
 
 
-		natTable.addConfiguration(new MinovaEditConfiguration(table.getColumns()));
 
 		natTable.setLayoutData(GridDataFactory.fillDefaults().grab(true, true).create());
-//		
 
-//		DataLayer bodyDataLayer = new DataLayer(bodyDataProvider);
-//
-//		SelectionLayer selectionLayer = new SelectionLayer(bodyDataLayer);
-//		ViewportLayer viewportLayer = new ViewportLayer(selectionLayer);
-//
-//		IDataProvider columnHeaderDataProvider = new DefaultColumnHeaderDataProvider(
-//				propertyNames,propertyToLabelMap);
-//		DataLayer columnHeaderDataLayer = new DefaultColumnHeaderDataLayer(columnHeaderDataProvider);
-//		ILayer columnHeaderLayer = new ColumnHeaderLayer(columnHeaderDataLayer, viewportLayer, selectionLayer);
-//
-//		SortHeaderLayer<Person> sortHeaderLayer = new SortHeaderLayer<>(columnHeaderLayer,
-//				new GlazedListsSortModel<>(sortedList, accessor, configRegistry, columnHeaderDataLayer));
-//
-//		CompositeLayer compositeLayer = new CompositeLayer(1, 2);
-//		compositeLayer.setChildLayer(GridRegion.COLUMN_HEADER, sortHeaderLayer, 0, 0);
-//		compositeLayer.setChildLayer(GridRegion.BODY, viewportLayer, 0, 1);
-
-//		NatTable natTable = new NatTable(parent, compositeLayer, false);
-//
-//		natTable.setConfigRegistry(configRegistry);
-//		natTable.addConfiguration(new DefaultNatTableStyleConfiguration());
-//		natTable.addConfiguration(new SingleClickSortConfiguration());
-
-		natTable.configure();
-		// set the modern theme to visualize the summary better
-
-//		ThemeConfiguration modernTheme = new ModernNatTableThemeConfiguration();
-//		modernTheme.addThemeExtension(new ModernGroupByThemeExtension());
-//
-//		natTable.setTheme(modernTheme);
-
-		return this;
+		return natTable;
 
 	}
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCIndexPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCIndexPart.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.annotation.PostConstruct;
@@ -14,11 +16,49 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.di.extensions.Preference;
+import org.eclipse.e4.core.services.translation.TranslationService;
 import org.eclipse.e4.ui.di.UIEventTopic;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.ESelectionService;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.nebula.widgets.nattable.NatTable;
+import org.eclipse.nebula.widgets.nattable.config.ConfigRegistry;
+import org.eclipse.nebula.widgets.nattable.config.DefaultNatTableStyleConfiguration;
+import org.eclipse.nebula.widgets.nattable.data.IColumnPropertyAccessor;
+import org.eclipse.nebula.widgets.nattable.data.IDataProvider;
+import org.eclipse.nebula.widgets.nattable.data.IRowDataProvider;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.GlazedListsEventLayer;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.GlazedListsSortModel;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.groupBy.GroupByDataLayer;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.groupBy.GroupByHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.groupBy.GroupByHeaderMenuConfiguration;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.groupBy.GroupByModel;
+import org.eclipse.nebula.widgets.nattable.grid.data.DefaultColumnHeaderDataProvider;
+import org.eclipse.nebula.widgets.nattable.grid.data.DefaultCornerDataProvider;
+import org.eclipse.nebula.widgets.nattable.grid.data.DefaultRowHeaderDataProvider;
+import org.eclipse.nebula.widgets.nattable.grid.layer.ColumnHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.CornerLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.DefaultColumnHeaderDataLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.DefaultRowHeaderDataLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.GridLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.RowHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.layer.AbstractLayerTransform;
+import org.eclipse.nebula.widgets.nattable.layer.CompositeLayer;
+import org.eclipse.nebula.widgets.nattable.layer.DataLayer;
+import org.eclipse.nebula.widgets.nattable.layer.ILayer;
+import org.eclipse.nebula.widgets.nattable.layer.ILayerListener;
+import org.eclipse.nebula.widgets.nattable.layer.cell.ColumnLabelAccumulator;
+import org.eclipse.nebula.widgets.nattable.layer.event.ILayerEvent;
+import org.eclipse.nebula.widgets.nattable.resize.command.AutoResizeColumnsCommand;
+import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer;
+import org.eclipse.nebula.widgets.nattable.selection.SelectionUtils;
+import org.eclipse.nebula.widgets.nattable.sort.SortHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.sort.config.SingleClickSortConfiguration;
+import org.eclipse.nebula.widgets.nattable.tree.TreeLayer;
+import org.eclipse.nebula.widgets.nattable.tree.config.TreeLayerExpandCollapseKeyBindings;
+import org.eclipse.nebula.widgets.nattable.viewport.ViewportLayer;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.forms.widgets.FormToolkit;
@@ -27,14 +67,20 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import aero.minova.rcp.dataservice.IMinovaJsonService;
+import aero.minova.rcp.form.model.xsd.Column;
 import aero.minova.rcp.form.model.xsd.Form;
+import aero.minova.rcp.model.Row;
 import aero.minova.rcp.model.Table;
 import aero.minova.rcp.model.Value;
 import aero.minova.rcp.model.ValueDeserializer;
 import aero.minova.rcp.model.ValueSerializer;
-import aero.minova.rcp.rcp.nattable.NatTableWrapper;
+import aero.minova.rcp.nattable.data.MinovaColumnPropertyAccessor;
 import aero.minova.rcp.rcp.util.Constants;
 import aero.minova.rcp.rcp.util.PersistTableSelection;
+import ca.odell.glazedlists.EventList;
+import ca.odell.glazedlists.GlazedLists;
+import ca.odell.glazedlists.SortedList;
+import ca.odell.glazedlists.TransformedList;
 
 public class WFCIndexPart extends WFCFormPart {
 
@@ -54,11 +100,15 @@ public class WFCIndexPart extends WFCFormPart {
 
 	private Composite composite;
 
-	private NatTableWrapper natTable;
-
 	private Gson gson;
 
+	private NatTable natTable;
+	private BodyLayerStack<Row> bodyLayerStack;
+	private IEclipseContext context;
 
+
+	@Inject
+	TranslationService translationService;
 
 	@PostConstruct
 	public void createComposite(Composite parent, MPart part, EModelService modelService) {
@@ -81,9 +131,8 @@ public class WFCIndexPart extends WFCFormPart {
 		}
 
 		parent.setLayout(new GridLayout());
-		MPerspective perspectiveFor = modelService.getPerspectiveFor(part);
-		natTable = new NatTableWrapper().createNatTable(parent, form, data, true, selectionService,
-				perspectiveFor.getContext());
+
+		natTable = createNatTable(parent, form, data, selectionService, perspective.getContext());
 
 
 		gson = new Gson();
@@ -102,7 +151,7 @@ public class WFCIndexPart extends WFCFormPart {
 			if (!content.equals("")) {
 				Table indexTable = gson.fromJson(content, Table.class);
 				if (indexTable.getRows() != null) {
-					natTable.updateData(indexTable.getRows());
+					updateData(indexTable.getRows());
 				}
 			}
 
@@ -126,7 +175,7 @@ public class WFCIndexPart extends WFCFormPart {
 	public void load(@UIEventTopic(Constants.BROKER_LOADINDEXTABLE) Map<MPerspective, Table> map) {
 		if (map.get(perspective) != null) {
 			Table table = map.get(perspective);
-			natTable.updateData(table.getRows());
+			updateData(table.getRows());
 
 			try {
 				Path file = Path.of(dataService.getStoragePath().toString(), "cache" + "jsonTableIndex");
@@ -136,6 +185,246 @@ public class WFCIndexPart extends WFCFormPart {
 				e.printStackTrace();
 			}
 		}
+	}
+
+	public NatTable createNatTable(Composite parent, Form form, Table table, ESelectionService selectionService,
+			IEclipseContext context) {
+
+		this.context = context;
+		Map<String, String> tableHeadersMap = new HashMap<>();
+		List<Column> columns = form.getIndexView().getColumn();
+		String[] propertyNames = new String[columns.size()];
+		int i = 0;
+		for (Column column : columns) {
+			String translate = translationService.translate(column.getLabel(), null);
+			tableHeadersMap.put(column.getName(), translate);
+			propertyNames[i++] = column.getName();
+		}
+
+		// Datenmodel für die Eingaben
+		ConfigRegistry configRegistry = new ConfigRegistry();
+		IColumnPropertyAccessor<Row> columnPropertyAccessor = new MinovaColumnPropertyAccessor(table);
+
+		// create the body stack
+		bodyLayerStack = new BodyLayerStack<>(table.getRows(), columnPropertyAccessor);
+
+
+		// build the column header layer
+		IDataProvider columnHeaderDataProvider = new DefaultColumnHeaderDataProvider(propertyNames, tableHeadersMap);
+		DataLayer columnHeaderDataLayer = new DefaultColumnHeaderDataLayer(columnHeaderDataProvider);
+		ColumnHeaderLayer columnHeaderLayer = new ColumnHeaderLayer(columnHeaderDataLayer, bodyLayerStack,
+				bodyLayerStack.getSelectionLayer());
+
+		SortHeaderLayer<Row> sortHeaderLayer = new SortHeaderLayer<>(columnHeaderLayer, new GlazedListsSortModel<>(
+				bodyLayerStack.getSortedList(), columnPropertyAccessor, configRegistry, columnHeaderDataLayer));
+
+		// build the row header layer
+		IDataProvider rowHeaderDataProvider = new DefaultRowHeaderDataProvider(bodyLayerStack.getBodyDataProvider());
+		DataLayer rowHeaderDataLayer = new DefaultRowHeaderDataLayer(rowHeaderDataProvider);
+		ILayer rowHeaderLayer = new RowHeaderLayer(rowHeaderDataLayer, bodyLayerStack,
+				bodyLayerStack.getSelectionLayer());
+
+		// build the corner layer
+		IDataProvider cornerDataProvider = new DefaultCornerDataProvider(columnHeaderDataProvider,
+				rowHeaderDataProvider);
+		DataLayer cornerDataLayer = new DataLayer(cornerDataProvider);
+		ILayer cornerLayer = new CornerLayer(cornerDataLayer, rowHeaderLayer, columnHeaderLayer);
+
+		// build the grid layer
+		GridLayer gridLayer = new GridLayer(bodyLayerStack, sortHeaderLayer, rowHeaderLayer, cornerLayer);
+
+		// set the group by header on top of the grid
+		CompositeLayer compositeGridLayer = new CompositeLayer(1, 2);
+		GroupByHeaderLayer groupByHeaderLayer = new GroupByHeaderLayer(bodyLayerStack.getGroupByModel(), gridLayer,
+				columnHeaderDataProvider, columnHeaderLayer);
+		compositeGridLayer.setChildLayer(GroupByHeaderLayer.GROUP_BY_REGION, groupByHeaderLayer, 0, 0);
+		compositeGridLayer.setChildLayer("Grid", gridLayer, 0, 1);
+
+		natTable = new NatTable(parent, compositeGridLayer, false);
+
+
+		// as the autoconfiguration of the NatTable is turned off, we have to
+		// add the DefaultNatTableStyleConfiguration and the ConfigRegistry
+		// manually
+		natTable.setConfigRegistry(configRegistry);
+		natTable.addConfiguration(new DefaultNatTableStyleConfiguration());
+		natTable.addConfiguration(new SingleClickSortConfiguration());
+
+//		natTable.registerCommandHandler(new DisplayPersistenceDialogCommandHandler(natTable));
+//
+//		// add group by configuration
+		natTable.addConfiguration(new GroupByHeaderMenuConfiguration(natTable, groupByHeaderLayer));
+		// adds the key bindings that allow space bar to be pressed to
+		// expand/collapse tree nodes
+		natTable.addConfiguration(new TreeLayerExpandCollapseKeyBindings(bodyLayerStack.getTreeLayer(),
+				bodyLayerStack.getSelectionLayer()));
+
+		natTable.configure();
+		natTable.setLayoutData(GridDataFactory.fillDefaults().grab(true, true).create());
+
+		return natTable;
+
+	}
+
+	/**
+	 * Always encapsulate the body layer stack in an AbstractLayerTransform to
+	 * ensure that the index transformations are performed in later commands.
+	 *
+	 * @param <T>
+	 */
+	class BodyLayerStack<T> extends AbstractLayerTransform {
+
+		private final SortedList<T> sortedList;
+
+		private final IDataProvider bodyDataProvider;
+
+		private final SelectionLayer selectionLayer;
+
+		private final GroupByModel groupByModel = new GroupByModel();
+
+		private EventList<T> eventList;
+
+		private GroupByDataLayer<T> bodyDataLayer;
+
+		private TreeLayer treeLayer;
+
+		public BodyLayerStack(List<T> values, IColumnPropertyAccessor<T> columnPropertyAccessor) {
+			eventList = GlazedLists.eventList(values);
+			TransformedList<T, T> rowObjectsGlazedList = GlazedLists.threadSafeList(eventList);
+
+			// use the SortedList constructor with 'null' for the Comparator
+			// because the Comparator
+			// will be set by configuration
+			this.sortedList = new SortedList<>(rowObjectsGlazedList, null);
+
+			bodyDataLayer = new GroupByDataLayer<>(getGroupByModel(), this.sortedList, columnPropertyAccessor);
+
+			// we register a custom UpdateDataCommandHandler so that we could add a new
+			// value if desired
+			// alternative we could add a new line during line selection
+//			this.bodyDataLayer.unregisterCommandHandler(UpdateDataCommand.class);
+//			this.bodyDataLayer.registerCommandHandler(new UpdateDataCommandHandler(this.bodyDataLayer) {
+//				@SuppressWarnings("unchecked")
+//				@Override
+//				protected boolean doCommand(UpdateDataCommand command) {
+//					if (super.doCommand(command)) {
+//						System.out.println("Custom update handler called");
+//						return true;
+//					}
+//					return false;
+//				}
+//			});
+
+
+			// get the IDataProvider that was created by the GroupByDataLayer
+			this.bodyDataProvider = bodyDataLayer.getDataProvider();
+
+			// Apply a ColumnLabelAccumulator to address the columns in the
+			// EditConfiguration class
+			// first colum starts at 0, etc
+			ColumnLabelAccumulator columnLabelAccumulator = new ColumnLabelAccumulator(bodyDataProvider);
+			bodyDataLayer.setConfigLabelAccumulator(columnLabelAccumulator);
+
+			// layer for event handling of GlazedLists and PropertyChanges
+			GlazedListsEventLayer<T> glazedListsEventLayer = new GlazedListsEventLayer<>(bodyDataLayer,
+					this.sortedList);
+
+			this.selectionLayer = new SelectionLayer(glazedListsEventLayer);
+
+			selectionLayer.addLayerListener(new ILayerListener() {
+
+				@Override
+				public void handleLayerEvent(ILayerEvent event) {
+					Object c = SelectionUtils.getSelectedRowObjects(selectionLayer,
+							(IRowDataProvider<T>) bodyDataProvider, false);
+					context.set("ActiveRows", c);
+				}
+			});
+
+
+			treeLayer = new TreeLayer(this.selectionLayer, bodyDataLayer.getTreeRowModel());
+
+			ViewportLayer viewportLayer = new ViewportLayer(treeLayer);
+
+			setUnderlyingLayer(viewportLayer);
+		}
+
+		public SelectionLayer getSelectionLayer() {
+			return this.selectionLayer;
+		}
+
+		public SortedList<T> getSortedList() {
+			return this.sortedList;
+		}
+
+		public GroupByDataLayer<T> getBodyDataLayer() {
+			return this.bodyDataLayer;
+		}
+
+		public TreeLayer getTreeLayer() {
+			return this.treeLayer;
+		}
+		public IDataProvider getBodyDataProvider() {
+			return this.bodyDataProvider;
+		}
+
+		public GroupByModel getGroupByModel() {
+			return this.groupByModel;
+		}
+
+		public EventList<T> getList() {
+			return eventList;
+		}
+	}
+
+	public static void resizeTable(NatTable table) {
+		if (!table.isDisposed()) {
+
+			/*
+			 * Collection<ILayer> underlyingLayersByColumnPosition =
+			 * table.getUnderlyingLayersByColumnPosition(0); int[] selectedColumnPositions =
+			 * null; for (ILayer iLayer : underlyingLayersByColumnPosition) {
+			 * 
+			 * if (iLayer instanceof ViewportLayer)
+			 * 
+			 * { int minColumnPosition = ((ViewportLayer)
+			 * iLayer).getMinimumOriginColumnPosition();
+			 * 
+			 * int columnCount = ((ViewportLayer) iLayer).getColumnCount();
+			 * 
+			 * int maxColumnPosition = minColumnPosition + columnCount - 1;
+			 * 
+			 * selectedColumnPositions = new int[columnCount];
+			 * 
+			 * for (int i = minColumnPosition; i <= maxColumnPosition; i++) {
+			 * 
+			 * int idx = i - minColumnPosition;
+			 * 
+			 * selectedColumnPositions[idx] = i;
+			 * 
+			 * }
+			 * 
+			 * }
+			 */
+
+			int[] selectedColumnPositions = new int[table.getColumnCount()];
+
+			for (int i = table.getColumnCount() - 1; i > -1; i--) {
+
+				selectedColumnPositions[i] = i;
+
+			}
+
+			// }
+			AutoResizeColumnsCommand columnCommand = new AutoResizeColumnsCommand(table, false,
+					selectedColumnPositions);
+
+			table.doCommand(columnCommand);
+		}
+	}
+	public void updateData(List<Row> list) {
+		bodyLayerStack.getSortedList().clear();
+		bodyLayerStack.getSortedList().addAll(list);
 	}
 
 }

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCSearchPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCSearchPart.java
@@ -1,5 +1,9 @@
 package aero.minova.rcp.rcp.parts;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
@@ -8,8 +12,37 @@ import javax.inject.Named;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.di.extensions.Preference;
+import org.eclipse.e4.core.services.translation.TranslationService;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.nebula.widgets.nattable.NatTable;
+import org.eclipse.nebula.widgets.nattable.config.ConfigRegistry;
+import org.eclipse.nebula.widgets.nattable.config.DefaultNatTableStyleConfiguration;
+import org.eclipse.nebula.widgets.nattable.data.IColumnPropertyAccessor;
+import org.eclipse.nebula.widgets.nattable.data.IDataProvider;
+import org.eclipse.nebula.widgets.nattable.data.ListDataProvider;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.GlazedListsEventLayer;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.GlazedListsSortModel;
+import org.eclipse.nebula.widgets.nattable.grid.GridRegion;
+import org.eclipse.nebula.widgets.nattable.grid.data.DefaultColumnHeaderDataProvider;
+import org.eclipse.nebula.widgets.nattable.grid.data.DefaultCornerDataProvider;
+import org.eclipse.nebula.widgets.nattable.grid.data.DefaultRowHeaderDataProvider;
+import org.eclipse.nebula.widgets.nattable.grid.layer.ColumnHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.CornerLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.DefaultColumnHeaderDataLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.DefaultRowHeaderDataLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.GridLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.RowHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.hideshow.ColumnHideShowLayer;
+import org.eclipse.nebula.widgets.nattable.layer.DataLayer;
+import org.eclipse.nebula.widgets.nattable.layer.ILayer;
+import org.eclipse.nebula.widgets.nattable.layer.cell.ColumnLabelAccumulator;
+import org.eclipse.nebula.widgets.nattable.reorder.ColumnReorderLayer;
+import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer;
+import org.eclipse.nebula.widgets.nattable.sort.SortHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.sort.config.SingleClickSortConfiguration;
+import org.eclipse.nebula.widgets.nattable.viewport.ViewportLayer;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.forms.widgets.FormToolkit;
@@ -19,13 +52,19 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import aero.minova.rcp.dataservice.IMinovaJsonService;
+import aero.minova.rcp.form.model.xsd.Column;
 import aero.minova.rcp.form.model.xsd.Form;
+import aero.minova.rcp.model.Row;
 import aero.minova.rcp.model.Table;
 import aero.minova.rcp.model.Value;
 import aero.minova.rcp.model.ValueDeserializer;
 import aero.minova.rcp.model.ValueSerializer;
-import aero.minova.rcp.rcp.nattable.NatTableWrapper;
+import aero.minova.rcp.nattable.data.MinovaColumnPropertyAccessor;
+import aero.minova.rcp.rcp.nattable.MinovaEditConfiguration;
 import aero.minova.rcp.rcp.util.PersistTableSelection;
+import ca.odell.glazedlists.EventList;
+import ca.odell.glazedlists.GlazedLists;
+import ca.odell.glazedlists.SortedList;
 
 public class WFCSearchPart extends WFCFormPart {
 
@@ -35,15 +74,18 @@ public class WFCSearchPart extends WFCFormPart {
 
 	@Inject
 	private IMinovaJsonService mjs;
+	@Inject
+	TranslationService translationService;
 
 	@Inject
 	private MPerspective perspective;
 
 	private Table data;
 
-	private NatTableWrapper natTable;
+	private NatTable natTable;
 
 	private Gson gson;
+
 
 	@Inject
 	MPart mPart;
@@ -69,7 +111,7 @@ public class WFCSearchPart extends WFCFormPart {
 
 		parent.setLayout(new GridLayout());
 		mPart.getContext().set("NatTableDataSearchArea", data);
-		natTable = new NatTableWrapper().createNatTable(parent, form, data, false, null, context);
+		natTable = createNatTable(parent, form, data);
 
 		gson = new Gson();
 		gson = new GsonBuilder() //
@@ -95,6 +137,92 @@ public class WFCSearchPart extends WFCFormPart {
 //			e.printStackTrace();
 //		}
 
+	}
+
+	public NatTable createNatTable(Composite parent, Form form, Table table) {
+
+		Map<String, String> tableHeadersMap = new HashMap<>();
+		List<Column> columns = form.getIndexView().getColumn();
+		String[] propertyNames = new String[columns.size()];
+		int i = 0;
+		for (Column column : columns) {
+			String translate = translationService.translate(column.getLabel(), null);
+			tableHeadersMap.put(column.getName(), translate);
+			propertyNames[i++] = column.getName();
+		}
+
+		// Datenmodel für die Eingaben
+		ConfigRegistry configRegistry = new ConfigRegistry();
+
+		// create the body stack
+		EventList<Row> eventList = GlazedLists.eventList(table.getRows());
+		SortedList<Row> sortedList = new SortedList<>(eventList, null);
+		IColumnPropertyAccessor<Row> accessor = new MinovaColumnPropertyAccessor(table);
+
+		IDataProvider bodyDataProvider = new ListDataProvider<Row>(sortedList, accessor);
+
+		DataLayer bodyDataLayer = new DataLayer(bodyDataProvider);
+
+		GlazedListsEventLayer<Row> eventLayer = new GlazedListsEventLayer<>(bodyDataLayer, sortedList);
+
+		ColumnReorderLayer columnReorderLayer = new ColumnReorderLayer(eventLayer);
+		ColumnHideShowLayer columnHideShowLayer = new ColumnHideShowLayer(columnReorderLayer);
+		SelectionLayer selectionLayer = new SelectionLayer(columnHideShowLayer);
+		ViewportLayer viewportLayer = new ViewportLayer(selectionLayer);
+
+		// as the selection mouse bindings are registered for the region label
+		// GridRegion.BODY
+		// we need to set that region label to the viewport so the selection via mouse
+		// is working correctly
+		viewportLayer.setRegionName(GridRegion.BODY);
+
+		// build the column header layer
+		IDataProvider columnHeaderDataProvider = new DefaultColumnHeaderDataProvider(propertyNames, tableHeadersMap);
+		DataLayer columnHeaderDataLayer = new DefaultColumnHeaderDataLayer(columnHeaderDataProvider);
+		ILayer columnHeaderLayer = new ColumnHeaderLayer(columnHeaderDataLayer, viewportLayer, selectionLayer);
+
+		columnHeaderDataLayer.setConfigLabelAccumulator(new ColumnLabelAccumulator());
+
+		SortHeaderLayer<Row> sortHeaderLayer = new SortHeaderLayer<>(columnHeaderLayer,
+				new GlazedListsSortModel<>(sortedList, accessor, configRegistry, columnHeaderDataLayer), false);
+
+		// build the row header layer
+		IDataProvider rowHeaderDataProvider = new DefaultRowHeaderDataProvider(bodyDataProvider);
+		DataLayer rowHeaderDataLayer = new DefaultRowHeaderDataLayer(rowHeaderDataProvider);
+		ILayer rowHeaderLayer = new RowHeaderLayer(rowHeaderDataLayer, viewportLayer, selectionLayer);
+
+		// build the corner layer
+		IDataProvider cornerDataProvider = new DefaultCornerDataProvider(columnHeaderDataProvider,
+				rowHeaderDataProvider);
+		DataLayer cornerDataLayer = new DataLayer(cornerDataProvider);
+		ILayer cornerLayer = new CornerLayer(cornerDataLayer, rowHeaderLayer, columnHeaderLayer);
+
+		// build the grid layer
+		GridLayer gridLayer = new GridLayer(viewportLayer, sortHeaderLayer, rowHeaderLayer, cornerLayer);
+
+		natTable = new NatTable(parent, gridLayer, false);
+
+		// as the autoconfiguration of the NatTable is turned off, we have to
+		// add the DefaultNatTableStyleConfiguration and the ConfigRegistry
+		// manually
+		natTable.setConfigRegistry(configRegistry);
+		natTable.addConfiguration(new DefaultNatTableStyleConfiguration());
+		natTable.addConfiguration(new SingleClickSortConfiguration());
+//		natTable.registerCommandHandler(new DisplayPersistenceDialogCommandHandler(natTable));
+//
+
+		natTable.addConfiguration(new MinovaEditConfiguration(table.getColumns()));
+
+		natTable.setLayoutData(GridDataFactory.fillDefaults().grab(true, true).create());
+
+		natTable.configure();
+		// set the modern theme to visualize the summary better
+
+//		ThemeConfiguration modernTheme = new ModernNatTableThemeConfiguration();
+//		modernTheme.addThemeExtension(new ModernGroupByThemeExtension());
+//
+//		natTable.setTheme(modernTheme);
+		return natTable;
 	}
 
 	@PersistTableSelection


### PR DESCRIPTION
Trennung der Implementierung von Search und Index part
Index part ist nicht mehr editierbar
Search part erlaubt Sortieren und Umgruppierung
Index part kann Selektion vom Search part lesen
Propagierung via Selection Service wieder funktionsfähig ohne Fehler
beim zweitem Selektieren
NattableWrapper gelöscht


Conflicts:
	bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCIndexPart.java
	bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/XMLIndexPart.java
	bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/XMLSearchPart.java