### PR TITLE
Upload RCP zip product with Github Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,3 +20,17 @@ jobs:
         java-version: 11
     - name: Build with Maven
       run: mvn clean verify --file pom.xml -T4
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: minova-wfc-linux
+        path: /home/runner/work/aero.minova.rcp/aero.minova.rcp/releng/aero.minova.rcp.product/target/products/*linux*.zip
+    - uses: actions/upload-artifact@v2
+      with:
+        name: minova-wfc-mac
+        path: /home/runner/work/aero.minova.rcp/aero.minova.rcp/releng/aero.minova.rcp.product/target/products/*mac*.zip
+    - uses: actions/upload-artifact@v2
+      with:
+        name: minova-wfc-win
+        path: /home/runner/work/aero.minova.rcp/aero.minova.rcp/releng/aero.minova.rcp.product/target/products/*win*.zip
+    


### PR DESCRIPTION
Jetzt mit vollen Pfad zu den Zip files
Platform spezifischen Artifacts werden einzelnd hochgeladen und damit
können diese vom Kunden heruntergeladen werden.