### PR TITLE
Nutzung von Tycho 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho.version>2.1.0</tycho.version>
+		<tycho.version>2.2.0</tycho.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 	</properties>


### PR DESCRIPTION
Erlaubt das neue Feature von PDE zu nutzen in seinem Target auch direkt
Maven libraries zu verwenden.