### PR TITLE
Fix multiple initialisierung von DataService

### DIFF
--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
@@ -75,6 +75,7 @@ public class DataService implements IDataService {
 		this.username = username;
 		this.password = password;
 		this.server = server;
+		init();
 	}
 
 	private void init() {
@@ -90,7 +91,6 @@ public class DataService implements IDataService {
 				.sslContext(disabledSslVerificationContext())//
 				.authenticator(authentication).build();
 
-		gson = new Gson();
 		gson = new GsonBuilder() //
 				.registerTypeAdapter(Value.class, new ValueSerializer()) //
 				.registerTypeAdapter(Value.class, new ValueDeserializer()) //
@@ -100,7 +100,6 @@ public class DataService implements IDataService {
 
 	@Override
 	public CompletableFuture<Table> getIndexDataAsync(String tableName, Table seachTable) {
-		init();
 		String body = gson.toJson(seachTable);
 
 		HttpRequest request = HttpRequest.newBuilder().uri(URI.create(server + "/data/index")) //
@@ -118,7 +117,6 @@ public class DataService implements IDataService {
 
 	@Override
 	public CompletableFuture<SqlProcedureResult> getDetailDataAsync(String tableName, Table detailTable) {
-		init();
 		String body = gson.toJson(detailTable);
 		HttpRequest request = HttpRequest.newBuilder().uri(URI.create(server + "/data/procedure")) //
 				.header("Content-Type", "application/json") //
@@ -245,7 +243,6 @@ public class DataService implements IDataService {
 	 */
 	@Override
 	public File getFileSynch(String localPath, String filename) {
-		init();
 		HttpRequest request = HttpRequest.newBuilder().uri(URI.create(server + "/files/read?path=" + filename))
 				.header("Content-Type", "application/octet-stream") //
 				.build();
@@ -268,7 +265,6 @@ public class DataService implements IDataService {
 	 */
 	@Override
 	public CompletableFuture<String> getFile(String filename) {
-		init();
 		HttpRequest request = HttpRequest.newBuilder().uri(URI.create(server + "/files/read?path=" + filename))
 				.header("Content-Type", "application/octet-stream") //
 				.build();


### PR DESCRIPTION
init() Aufruf sollten nur einmalig benötigt werden, von daher wird der
Aufruf bei den einzelnen Methoden entfernt und in das Setzen des
Passwords überführt. Weiterhin wird die doppelte initialisierung von
GSON entfernt.