### PR TITLE
Entfernt Bintray update site

### DIFF
--- a/bundles/aero.minova.rcp.dataservice/META-INF/MANIFEST.MF
+++ b/bundles/aero.minova.rcp.dataservice/META-INF/MANIFEST.MF
@@ -12,8 +12,7 @@ Require-Bundle: aero.minova.rcp.model;bundle-version="1.2.0",
  org.eclipse.e4.ui.model.workbench,
  org.eclipse.e4.core.contexts;bundle-version="1.8.400",
  org.eclipse.osgi.services,
- org.eclipse.swt,
- org.h2;bundle-version="1.4.197"
+ org.eclipse.swt
 Export-Package: aero.minova.rcp.dataservice,
  aero.minova.rcp.dataservice.internal
 Import-Package: aero.minova.rcp.form.model.xsd,

--- a/releng/aero.minova.rcp.product/aero.minova.rcp.rcp.product
+++ b/releng/aero.minova.rcp.product/aero.minova.rcp.rcp.product
@@ -3,7 +3,6 @@
 
 <product name="WFC" uid="WebFatClient" id="aero.minova.rcp.rcp.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="1.2.1.qualifier" useFeatures="true" includeLaunchers="true">
 
-
    <configIni use="default">
    </configIni>
 
@@ -23,7 +22,6 @@
          <bmp/>
       </win>
    </launcher>
-
 
    <vm>
    </vm>
@@ -111,7 +109,6 @@
       <feature id="org.eclipse.e4.rcp" installMode="root"/>
       <feature id="org.eclipse.emf.ecore" installMode="root"/>
       <feature id="org.eclipse.emf.common" installMode="root"/>
-      <feature id="h2" installMode="root"/>
    </features>
 
    <configurations>

--- a/releng/target-definition/eclipse-2020-12.target
+++ b/releng/target-definition/eclipse-2020-12.target
@@ -140,13 +140,5 @@
 		<unit id="javax.xml.stream" version="1.0.1.v201004272200"/>
 		<unit id="javax.activation" version="1.1.0.v201211130549"/>
 	</location>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://dl.bintray.com/simon-scholz/H2-Database-Engine/"/>
-		<unit id="h2.feature.group" version="1.4.197"/>
-		<unit id="h2.source.feature.group" version="1.4.197"/>
-		<unit id="hibernate-osgi.feature.group" version="5.2.16.Final"/>
-		<unit id="hibernate-osgi.source.feature.group" version="5.2.16.Final"/>
-		<unit id="vogella-jpa-libs.feature.group" version="0.1.0"/>
-	</location>
 </locations>
 </target>


### PR DESCRIPTION
Bintray wird abgeschaltet und die Nutzung der H2 Datenbank ist schon
ausgebaut.

Fixed #274