### PR TITLE
File laden und persistieren vom LoadIndexHandler entfernt

### DIFF
--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/LoadIndexHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/LoadIndexHandler.java
@@ -1,11 +1,7 @@
 package aero.minova.rcp.rcp.handlers;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,14 +19,10 @@ import org.eclipse.e4.ui.workbench.modeling.EPartService;
 import org.eclipse.swt.widgets.Shell;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 
 import aero.minova.rcp.core.ui.PartsID;
 import aero.minova.rcp.dataservice.IDataService;
 import aero.minova.rcp.model.Table;
-import aero.minova.rcp.model.Value;
-import aero.minova.rcp.model.ValueDeserializer;
-import aero.minova.rcp.model.ValueSerializer;
 import aero.minova.rcp.rcp.util.Constants;
 
 public class LoadIndexHandler {
@@ -71,17 +63,17 @@ public class LoadIndexHandler {
 		findElements = model.findElements(perspective, PartsID.INDEX_PART, MPart.class);
 		partService.activate(findElements.get(0));
 
-		gson = new Gson();
-		gson = new GsonBuilder() //
-				.registerTypeAdapter(Value.class, new ValueSerializer()) //
-				.registerTypeAdapter(Value.class, new ValueDeserializer()) //
-				.setPrettyPrinting() //
-				.create();
-		Path path = Path.of(dataService.getStoragePath().toString(), "cache", "jsonTableSearch");
-
-		File jsonFile = new File(path.toString());
-		jsonFile.createNewFile();
-		Files.write(path, gson.toJson(table).getBytes(StandardCharsets.UTF_8));
+//		gson = new Gson();
+//		gson = new GsonBuilder() //
+//				.registerTypeAdapter(Value.class, new ValueSerializer()) //
+//				.registerTypeAdapter(Value.class, new ValueDeserializer()) //
+//				.setPrettyPrinting() //
+//				.create();
+//		Path path = Path.of(dataService.getStoragePath().toString(), "cache", "jsonTableSearch");
+//
+//		File jsonFile = new File(path.toString());
+//		jsonFile.createNewFile();
+//		Files.write(path, gson.toJson(table).getBytes(StandardCharsets.UTF_8));
 	}
 
 }


### PR DESCRIPTION
Der Client code soll sich nicht um das Persistiern der Daten kümmern,
dass soll in den Datenservice passiert. Weiterhin wurde die Logik die
alte Such zu speichern entfernt, da diese nicht verwendet wurde.

Falls wir das benötigen, sollten wir das über einen Service wrappen