### PR TITLE
JaxB fixes

### DIFF
--- a/bundles/aero.minova.rcp.dataservice/META-INF/MANIFEST.MF
+++ b/bundles/aero.minova.rcp.dataservice/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Version: 1.2.1.qualifier
 Automatic-Module-Name: aero.minova.rcp.dataservice
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: aero.minova.rcp.model;bundle-version="1.2.0",
- javax.xml.bind;bundle-version="2.2.0",
  org.eclipse.core.runtime;bundle-version="3.19.0",
  org.eclipse.e4.ui.di,
  org.eclipse.e4.ui.model.workbench,
@@ -17,6 +16,7 @@ Export-Package: aero.minova.rcp.dataservice,
  aero.minova.rcp.dataservice.internal
 Import-Package: aero.minova.rcp.form.model.xsd,
  com.google.gson;version="2.8.2",
+ javax.xml.bind;version="2.3.2",
  org.osgi.service.component.annotations;resolution:=optional
 Service-Component: OSGI-INF/aero.minova.rcp.dataservice.internal.DataFormService.xml,
  OSGI-INF/aero.minova.rcp.dataservice.internal.MinovaJsonService.xml,

--- a/tests/aero.minova.rcp.xml.tests/META-INF/MANIFEST.MF
+++ b/tests/aero.minova.rcp.xml.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit;bundle-version="4.12.0",
  aero.minova.rcp.model;bundle-version="1.2.0",
  com.google.gson;bundle-version="2.2.4",
- javax.xml.bind;bundle-version="2.2.0",
  org.eclipse.persistence.core;bundle-version="2.7.7",
  aero.minova.rcp.form.model,
  org.junit.jupiter.api;bundle-version="5.7.0",
@@ -17,4 +16,6 @@ Import-Package: aero.minova.rcp.dataservice.internal,
  aero.minova.rcp.form.model.xsd,
  aero.minova.rcp.rcp.util,
  aero.minova.workingtime.helper,
- com.google.gson;version="2.8.2"
+ com.google.gson;version="2.8.2",
+ javax.xml.bind;version="2.3.2",
+ org.eclipse.persistence.jaxb;version="2.7.7"


### PR DESCRIPTION
Kerstin und Martin haben manchmal Probleme beim Starten mit der
Fehlermeldung JaxB context cannot be cast

JaxB implementierung wird über Package imports auf das die Version 2.3.2
fixiert, löst das Problem für die Unittest unter Windows.