### PR TITLE
Entfernt Sirius von der rcp.model configuration

### DIFF
--- a/bundles/aero.minova.rcp.model/.project
+++ b/bundles/aero.minova.rcp.model/.project
@@ -27,7 +27,6 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.sirius.nature.modelingproject</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>

--- a/bundles/aero.minova.rcp.model/representations.aird
+++ b/bundles/aero.minova.rcp.model/representations.aird
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<viewpoint:DAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" uid="_vivCsBg-Eeud37tAaUY54w" version="14.3.1.202003261200"/>


### PR DESCRIPTION
Sirius wird Zeit nicht verwendet und damit der Marketplace client uns
nicht fragt, ob er das Tooling installieren