### PR TITLE
Anpassen des CSS für das Detail

### DIFF
--- a/bundles/aero.minova.rcp.css/css/colors.css
+++ b/bundles/aero.minova.rcp.css/css/colors.css
@@ -1,9 +1,9 @@
 CTabItem, LayoutComposite, ExpandableComposite,
 	ScrolledComposite, Canvas, DetailComposite, ToolBar,
-	LookupControl, NatTable {
+	LookupControl, NatTable, Section  {
 	background-color: COLOR-WIDGET-BACKGROUND;
 }
-Label, MinovaSection, Button {
+Label, Button, Section  {
 	color: #666666;
 	background-color: inherit;
 	/*
@@ -24,9 +24,14 @@ Composite, Label {
 }
 */
 
-MinovaSection, MinovaComposite {
+Composite {
 	background-color: COLOR-WIDGET-BACKGROUND;
-	background-color-titlebar: white;
+}
+
+
+Section {
+	background-color: COLOR-WIDGET-BACKGROUND;
+	background-color-titlebar: COLOR-WIDGET-BACKGROUND;
 	/*background-color-gradient-titlebar: #e9e9e9;*/
 	border-color-titlebar: black;
 }


### PR DESCRIPTION
Hintergrund und Überschriften im Detail sind grau statt hellblau