### PR TITLE
Pflicht- und Read-Only Felder anpassen

### DIFF
--- a/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
+++ b/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
@@ -77,6 +77,12 @@ public class Constants {
 	// Column Label für eigene Sortierung
 	public static final String COMPARATOR_LABEL = "CUSTOM_COMPARATOR_LABEL";
 
+	// CSS Klassennamen
+	public static final String CSS_STANDARD = "Standard";
+	public static final String CSS_REQUIRED = "ValueRequired";
+	public static final String CSS_INVALID = "InvalidValue";
+	public static final String CSS_READONLY = "ReadOnly";
+
 	/**
 	 * Hier werden Standard-Einstellungen definiert, die wirklich oft genutzt werden
 	 *

--- a/bundles/aero.minova.rcp.css/css/colors.css
+++ b/bundles/aero.minova.rcp.css/css/colors.css
@@ -39,22 +39,21 @@ CTabItem:selected {
 	background-color: white;
 }
 
-LookupText, Text {
+Text.Standard, Lookup.Standard, TextAssist.Standard {
 	color: black;
 	background-color: white;
 }
 
-LookupText.ValueRequired, Text.ValueRequired {
-	/*background-color: #FFC300;*/
+Text.ValueRequired, Lookup.ValueRequired, TextAssist.ValueRequired {
 	background-color: #FCD267;
 }
 
-LookupText.InvalidValue, Text.InvalidValue {
+Text.InvalidValue, Lookup.InvalidValue, TextAssist.InvalidValue {
 	color: white;
 	background-color: red;
 }
 
-LookupText.ReadOnly, Text.ReadOnly {
+Text.ReadOnly, Lookup.ReadOnly, TextAssist.ReadOnly {
 	background-color: inherit;
 }
 

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MDetail.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MDetail.java
@@ -81,12 +81,10 @@ public class MDetail {
 
 	public boolean allFieldsValid() {
 		for (MField field : fields.values()) {
-			System.out.println(field + " " + field.isValid());
 			if (!field.isValid()) {
 				return false;
 			}
 		}
-		System.out.println("--- All Valid");
 		return true;
 	}
 }

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MDetail.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MDetail.java
@@ -21,16 +21,16 @@ public class MDetail {
 	private IHelper helper;
 
 	/**
-	 * Ein neues Feld dem Detail hinzufügen. Dabei muss selbst auf die Eindeutigkeit
-	 * geachtet werden. Z.B.
+	 * Ein neues Feld dem Detail hinzufügen. Dabei muss selbst auf die Eindeutigkeit geachtet werden. Z.B.
 	 * <ul>
 	 * <li>"KeyLong" = Das Feld KeyLong der Detail-Maske</li>
-	 * <li>"CustomerUserCode.UserCode" = Das Feld UserCode in der Maske
-	 * CustomerUserCode.op.xml</li>
+	 * <li>"CustomerUserCode.UserCode" = Das Feld UserCode in der Maske CustomerUserCode.op.xml</li>
 	 * </ul>
 	 *
-	 * @param name  Name / ID des Feldes
-	 * @param field das eigentliche Feld
+	 * @param name
+	 *            Name / ID des Feldes
+	 * @param field
+	 *            das eigentliche Feld
 	 */
 	public void putField(MField field) {
 		if (field == null)
@@ -40,15 +40,14 @@ public class MDetail {
 	}
 
 	/**
-	 * Liefert das Feld mit dem Namen. Felder im Detail haben kein Präfix. Felder in
-	 * einer OptionPage haben das Präfix aus der XBS. z.B.
+	 * Liefert das Feld mit dem Namen. Felder im Detail haben kein Präfix. Felder in einer OptionPage haben das Präfix aus der XBS. z.B.
 	 * <ul>
 	 * <li>"KeyLong" = Das Feld KeyLong der Detail-Maske</li>
-	 * <li>"CustomerUserCode.UserCode" = Das Feld UserCode in der Maske
-	 * CustomerUserCode.op.xml</li>
+	 * <li>"CustomerUserCode.UserCode" = Das Feld UserCode in der Maske CustomerUserCode.op.xml</li>
 	 * </ul>
 	 *
-	 * @param name Name des Feldes
+	 * @param name
+	 *            Name des Feldes
 	 * @return Das Feld
 	 */
 	public MField getField(String name) {
@@ -78,5 +77,16 @@ public class MDetail {
 
 	public void setHelper(IHelper helper) {
 		this.helper = helper;
+	}
+
+	public boolean allFieldsValid() {
+		for (MField field : fields.values()) {
+			System.out.println(field + " " + field.isValid());
+			if (!field.isValid()) {
+				return false;
+			}
+		}
+		System.out.println("--- All Valid");
+		return true;
 	}
 }

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MField.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MField.java
@@ -277,6 +277,7 @@ public abstract class MField {
 	public void setValueAccessor(ValueAccessor valueAccessor) {
 		this.valueAccessor = valueAccessor;
 		updateCssClass(cssClass);
+		valueAccessor.setEditable(!readOnly);
 	}
 
 	public MDetail getDetail() {

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MField.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MField.java
@@ -31,6 +31,8 @@ public abstract class MField {
 	private Integer numberRowsSpanned = 1;
 	private Double maximumValue;
 	private Double minimumValue;
+
+	private int maxTextLength;
 	private boolean fillToRight = false;
 	private String lookupTable;
 	private String lookupProcedurePrefix;
@@ -122,6 +124,7 @@ public abstract class MField {
 		} else {
 			updateCssClass(Constants.CSS_STANDARD);
 		}
+		isValid();
 	}
 
 	/**
@@ -207,6 +210,14 @@ public abstract class MField {
 
 	public void setMinimumValue(Double maximumValue) {
 		this.minimumValue = maximumValue;
+	}
+
+	public int getMaxTextLength() {
+		return maxTextLength;
+	}
+
+	public void setMaxTextLength(int maxTextLength) {
+		this.maxTextLength = maxTextLength;
 	}
 
 	public boolean isFillToRight() {
@@ -321,13 +332,6 @@ public abstract class MField {
 		return "MField(" + getName() + ")";
 	}
 
-	public boolean isValid() {
-		if (!isRequired() || mSection == null) {
-			return true;
-		}
-		return fieldValue != null;
-	}
-
 	public void updateCssClass(String newClass) {
 		if (valueAccessor == null) {
 			return;
@@ -340,5 +344,16 @@ public abstract class MField {
 		}
 
 		valueAccessor.setCSSClass(newClass);
+	}
+
+	public boolean isValid() {
+		if (!isRequired() || mSection == null) {
+			return true;
+		}
+		return fieldValue != null;
+	}
+
+	public void setInvalidColor() {
+		updateCssClass(Constants.CSS_INVALID);
 	}
 }

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MField.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MField.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
+import aero.minova.rcp.constants.Constants;
 import aero.minova.rcp.model.DataType;
 import aero.minova.rcp.model.Table;
 import aero.minova.rcp.model.Value;
@@ -40,6 +41,7 @@ public abstract class MField {
 	private boolean readOnly;
 	private int tabIndex;
 	private MSection mSection;
+	private String cssClass = Constants.CSS_STANDARD;
 
 	protected MField(DataType dataType) {
 		this.dataType = dataType;
@@ -114,6 +116,12 @@ public abstract class MField {
 			displayValue = getValueAccessor().setValue(value, user);
 		}
 		fire(new ValueChangeEvent(this, oldValue, value, user));
+
+		if (value == null) {
+			updateCssClass(cssClass);
+		} else {
+			updateCssClass(Constants.CSS_STANDARD);
+		}
 	}
 
 	/**
@@ -258,6 +266,7 @@ public abstract class MField {
 
 	public void setValueAccessor(ValueAccessor valueAccessor) {
 		this.valueAccessor = valueAccessor;
+		updateCssClass(cssClass);
 	}
 
 	public MDetail getDetail() {
@@ -274,6 +283,10 @@ public abstract class MField {
 
 	public void setRequired(boolean required) {
 		this.required = required;
+		// Readonly hat Vorrang
+		if (required && !cssClass.equals(Constants.CSS_READONLY)) {
+			cssClass = Constants.CSS_REQUIRED;
+		}
 	}
 
 	public boolean isReadOnly() {
@@ -282,6 +295,9 @@ public abstract class MField {
 
 	public void setReadOnly(boolean readOnly) {
 		this.readOnly = readOnly;
+		if (readOnly) {
+			cssClass = Constants.CSS_READONLY;
+		}
 	}
 
 	public int getTabIndex() {
@@ -310,5 +326,19 @@ public abstract class MField {
 			return true;
 		}
 		return fieldValue != null;
+	}
+
+	public void updateCssClass(String newClass) {
+		if (valueAccessor == null) {
+			return;
+		}
+
+		// Readonly wird nie geändert
+		if (cssClass.equals(Constants.CSS_READONLY)) {
+			valueAccessor.setCSSClass(Constants.CSS_READONLY);
+			return;
+		}
+
+		valueAccessor.setCSSClass(newClass);
 	}
 }

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MField.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MField.java
@@ -40,7 +40,6 @@ public abstract class MField {
 	private boolean readOnly;
 	private int tabIndex;
 	private MSection mSection;
-	
 
 	protected MField(DataType dataType) {
 		this.dataType = dataType;
@@ -268,23 +267,23 @@ public abstract class MField {
 	void setDetail(MDetail detail) {
 		this.detail = detail;
 	}
-	
+
 	public boolean isRequired() {
 		return required;
 	}
-	
+
 	public void setRequired(boolean required) {
 		this.required = required;
 	}
-	
+
 	public boolean isReadOnly() {
 		return readOnly;
 	}
-	
+
 	public void setReadOnly(boolean readOnly) {
 		this.readOnly = readOnly;
 	}
-	
+
 	public int getTabIndex() {
 		return tabIndex;
 	}
@@ -304,5 +303,12 @@ public abstract class MField {
 	@Override
 	public String toString() {
 		return "MField(" + getName() + ")";
+	}
+
+	public boolean isValid() {
+		if (!isRequired() || mSection == null) {
+			return true;
+		}
+		return fieldValue != null;
 	}
 }

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MField.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MField.java
@@ -31,7 +31,6 @@ public abstract class MField {
 	private Integer numberRowsSpanned = 1;
 	private Double maximumValue;
 	private Double minimumValue;
-
 	private int maxTextLength;
 	private boolean fillToRight = false;
 	private String lookupTable;
@@ -346,6 +345,16 @@ public abstract class MField {
 		valueAccessor.setCSSClass(newClass);
 	}
 
+	/**
+	 * Kann (laut diesem Feld) gespeichtert werden
+	 * <p>
+	 * <ul>
+	 * <li>Nicht angezeigte Felder (mSection == null) oder Felder ohne "required" brauchen keinen Wert
+	 * <li>Ansonsten kann gespeichtert werden, wenn ein Wert eingetragen ist
+	 * </ul>
+	 * <p>
+	 * Weitere Validierung findet in Unterklassen statt (z.B. Textlänge in MTextField)
+	 */
 	public boolean isValid() {
 		if (!isRequired() || mSection == null) {
 			return true;

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MNumberField.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MNumberField.java
@@ -5,4 +5,33 @@ public class MNumberField extends MField {
 	public MNumberField(int decimals) {
 		super(decimals);
 	}
+
+	@Override
+	public boolean isValid() {
+		if (getValue() == null) {
+			return super.isValid();
+		}
+
+		double numberValue = 0;
+		if (getValue().getDoubleValue() != null) {
+			numberValue = getValue().getDoubleValue();
+		} else if (getValue().getIntegerValue() != null) {
+			numberValue = getValue().getIntegerValue();
+		}
+
+		boolean maxFits = true;
+		if (getMaximumValue() != null) {
+			maxFits = numberValue <= getMaximumValue();
+		}
+		boolean minFits = true;
+		if (getMinimumValue() != null) {
+			minFits = numberValue >= getMinimumValue();
+		}
+
+		boolean validTest = super.isValid() && minFits && maxFits;
+		if (!validTest) {
+			setInvalidColor();
+		}
+		return validTest;
+	}
 }

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MTextField.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MTextField.java
@@ -7,4 +7,18 @@ public class MTextField extends MField {
 	public MTextField() {
 		super(DataType.STRING);
 	}
+
+	@Override
+	public boolean isValid() {
+		if (getValue() == null) {
+			return super.isValid();
+		}
+
+		int textLength = getValue().getStringValue().length();
+		boolean validTest = super.isValid() && textLength > 0 && textLength < getMaxTextLength();
+		if (!validTest) {
+			setInvalidColor();
+		}
+		return validTest;
+	}
 }

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/ModelToViewModel.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/ModelToViewModel.java
@@ -33,6 +33,7 @@ public class ModelToViewModel {
 		} else if (field.getText() != null) {
 			f = new MTextField();
 			f.setFillToRight("toright".equals(field.getFill()));
+			f.setMaxTextLength(field.getText().getLength());
 		} else {
 			return null;
 		}

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/ValueAccessor.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/ValueAccessor.java
@@ -21,4 +21,6 @@ public interface ValueAccessor {
 	void setMessageText(String message);
 
 	void setEditable(boolean editable);
+
+	void setCSSClass(String classname);
 }

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/AbstractValueAccessor.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/AbstractValueAccessor.java
@@ -3,6 +3,7 @@ package aero.minova.rcp.rcp.accessor;
 import javax.inject.Inject;
 
 import org.eclipse.e4.ui.services.IStylingEngine;
+import org.eclipse.nebula.widgets.opal.textassist.TextAssist;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.widgets.Control;
@@ -67,10 +68,16 @@ public abstract class AbstractValueAccessor implements ValueAccessor {
 
 	@Override
 	public void setEditable(boolean editable) {
+		if (field.isReadOnly()) {
+			editable = false;
+		}
+
 		if (control instanceof Lookup) {
 			((Lookup) control).setEditable(editable);
 		} else if (control instanceof Text) {
 			((Text) control).setEditable(editable);
+		} else if (control instanceof TextAssist) {
+			((TextAssist) control).setEditable(editable);
 		}
 	}
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/AbstractValueAccessor.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/AbstractValueAccessor.java
@@ -1,5 +1,8 @@
 package aero.minova.rcp.rcp.accessor;
 
+import javax.inject.Inject;
+
+import org.eclipse.e4.ui.services.IStylingEngine;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.widgets.Control;
@@ -17,6 +20,9 @@ public abstract class AbstractValueAccessor implements ValueAccessor {
 	protected final Control control;
 	protected boolean focussed = false;
 	private Value displayValue;
+
+	@Inject
+	IStylingEngine engine;
 
 	public AbstractValueAccessor(MField field, Control control) {
 		super();
@@ -111,6 +117,13 @@ public abstract class AbstractValueAccessor implements ValueAccessor {
 
 	public Control getControl() {
 		return control;
+	}
+
+	@Override
+	public void setCSSClass(String classname) {
+		if (engine != null) {
+			engine.setClassname(control, classname);
+		}
 	}
 
 }

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/BooleanField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/BooleanField.java
@@ -9,6 +9,9 @@ import static aero.minova.rcp.rcp.fields.FieldUtil.TRANSLATE_PROPERTY;
 
 import java.util.Locale;
 
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
@@ -24,13 +27,15 @@ import aero.minova.rcp.rcp.accessor.BooleanValueAccessor;
 
 public class BooleanField {
 
-	public static Control create(Composite composite, MField field, int row, int column, FormToolkit formToolkit,
-			Locale locale) {
+	public static Control create(Composite composite, MField field, int row, int column, FormToolkit formToolkit, Locale locale, MPerspective perspective) {
 		String labelText = field.getLabel() == null ? "" : field.getLabel();
 		FormData formData = new FormData();
 		Button button = formToolkit.createButton(composite, field.getLabel(), SWT.CHECK);
 
-		field.setValueAccessor(new BooleanValueAccessor(field, button));
+		IEclipseContext context = perspective.getContext();
+		BooleanValueAccessor valueAccessor = new BooleanValueAccessor(field, button);
+		ContextInjectionFactory.inject(valueAccessor, context);
+		field.setValueAccessor(valueAccessor);
 
 		formData.width = COLUMN_WIDTH;
 		formData.top = new FormAttachment(composite, MARGIN_TOP + row * COLUMN_HEIGHT);

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/BooleanField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/BooleanField.java
@@ -32,6 +32,7 @@ public class BooleanField {
 		FormData formData = new FormData();
 		Button button = formToolkit.createButton(composite, field.getLabel(), SWT.CHECK);
 
+		// ValueAccessor in den Context injecten, damit IStylingEngine über @Inject verfügbar ist (in AbstractValueAccessor)
 		IEclipseContext context = perspective.getContext();
 		BooleanValueAccessor valueAccessor = new BooleanValueAccessor(field, button);
 		ContextInjectionFactory.inject(valueAccessor, context);

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/DateTimeField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/DateTimeField.java
@@ -76,6 +76,7 @@ public class DateTimeField {
 			}
 		});
 
+		// ValueAccessor in den Context injecten, damit IStylingEngine über @Inject verfügbar ist (in AbstractValueAccessor)
 		IEclipseContext context = perspective.getContext();
 		DateTimeValueAccessor valueAccessor = new DateTimeValueAccessor(field, text);
 		ContextInjectionFactory.inject(valueAccessor, context);

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/DateTimeField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/DateTimeField.java
@@ -17,6 +17,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.nebula.widgets.opal.textassist.TextAssist;
 import org.eclipse.nebula.widgets.opal.textassist.TextAssistContentProvider;
 import org.eclipse.swt.SWT;
@@ -36,7 +39,8 @@ import aero.minova.rcp.util.DateTimeUtil;
 
 public class DateTimeField {
 
-	public static Control create(Composite composite, MField field, int row, int column, FormToolkit formToolkit, Locale locale, String timezone) {
+	public static Control create(Composite composite, MField field, int row, int column, FormToolkit formToolkit, Locale locale, String timezone,
+			MPerspective perspective) {
 
 		String labelText = field.getLabel() == null ? "" : field.getLabel();
 		Label label = formToolkit.createLabel(composite, labelText, SWT.RIGHT);
@@ -72,7 +76,10 @@ public class DateTimeField {
 			}
 		});
 
-		field.setValueAccessor(new DateTimeValueAccessor(field, text));
+		IEclipseContext context = perspective.getContext();
+		DateTimeValueAccessor valueAccessor = new DateTimeValueAccessor(field, text);
+		ContextInjectionFactory.inject(valueAccessor, context);
+		field.setValueAccessor(valueAccessor);
 
 		FormData labelFormData = new FormData();
 		FormData textFormData = new FormData();

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/LookupField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/LookupField.java
@@ -42,7 +42,7 @@ public class LookupField {
 
 	public static final String AERO_MINOVA_RCP_LOOKUP = "LookUp";
 
-	public static Control create(Composite composite, MField field, int row, int column, FormToolkit formToolkit, MPerspective perspective, Locale locale) {
+	public static Control create(Composite composite, MField field, int row, int column, FormToolkit formToolkit, Locale locale, MPerspective perspective) {
 		String labelText = field.getLabel() == null ? "" : field.getLabel();
 		Label label = formToolkit.createLabel(composite, labelText, SWT.RIGHT);
 		LookupContentProvider lookUpContentProvider = new LookupContentProvider();
@@ -93,7 +93,7 @@ public class LookupField {
 			public void keyTraversed(TraverseEvent e) {
 				Text text = ((Text) e.getSource());
 				Lookup t = (Lookup) text.getParent();
-				System.out.println("Pressed key: " + e.keyCode);
+				// System.out.println("Pressed key: " + e.keyCode);
 				switch (e.detail) {
 				case SWT.TRAVERSE_TAB_PREVIOUS:
 					t.fillSelectedValue();

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/NumberField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/NumberField.java
@@ -13,6 +13,9 @@ import static aero.minova.rcp.rcp.fields.FieldUtil.TRANSLATE_PROPERTY;
 
 import java.util.Locale;
 
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusAdapter;
 import org.eclipse.swt.events.FocusEvent;
@@ -29,8 +32,8 @@ import aero.minova.rcp.rcp.accessor.NumberValueAccessor;
 
 public class NumberField {
 
-	public static Control create(Composite composite, MNumberField field, int row, int column, FormToolkit formToolkit,
-			Locale locale) {
+	public static Control create(Composite composite, MNumberField field, int row, int column, FormToolkit formToolkit, Locale locale,
+			MPerspective perspective) {
 		String labelText = field.getLabel() == null ? "" : field.getLabel();
 		String unitText = field.getUnitText() == null ? "" : field.getUnitText();
 		Label label = formToolkit.createLabel(composite, labelText, SWT.RIGHT);
@@ -45,6 +48,8 @@ public class NumberField {
 		});
 		text.addVerifyListener(numberValueAccessor);
 
+		IEclipseContext context = perspective.getContext();
+		ContextInjectionFactory.inject(numberValueAccessor, context);
 		field.setValueAccessor(numberValueAccessor);
 
 		Label unit = formToolkit.createLabel(composite, unitText, SWT.LEFT);
@@ -79,7 +84,7 @@ public class NumberField {
 		text.setData(FIELD_MIN_VALUE, minimum);
 		text.setLayoutData(textFormData);
 		NumberFieldUtil.setMessage(text);
-		
+
 		// TODO SAW_ERC korrigieren NumberFieldVerifier
 		// text.addVerifyListener(new NumberFieldVerifier(text));
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/NumberField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/NumberField.java
@@ -48,6 +48,7 @@ public class NumberField {
 		});
 		text.addVerifyListener(numberValueAccessor);
 
+		// ValueAccessor in den Context injecten, damit IStylingEngine über @Inject verfügbar ist (in AbstractValueAccessor)
 		IEclipseContext context = perspective.getContext();
 		ContextInjectionFactory.inject(numberValueAccessor, context);
 		field.setValueAccessor(numberValueAccessor);

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/ShortDateField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/ShortDateField.java
@@ -78,6 +78,7 @@ public class ShortDateField {
 			}
 		});
 
+		// ValueAccessor in den Context injecten, damit IStylingEngine über @Inject verfügbar ist (in AbstractValueAccessor)
 		IEclipseContext context = perspective.getContext();
 		ShortDateValueAccessor valueAccessor = new ShortDateValueAccessor(field, text);
 		ContextInjectionFactory.inject(valueAccessor, context);

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/ShortDateField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/ShortDateField.java
@@ -17,6 +17,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.nebula.widgets.opal.textassist.TextAssist;
 import org.eclipse.nebula.widgets.opal.textassist.TextAssistContentProvider;
 import org.eclipse.swt.SWT;
@@ -40,7 +43,8 @@ public class ShortDateField {
 		throw new IllegalStateException("Utility class");
 	}
 
-	public static Control create(Composite composite, MField field, int row, int column, FormToolkit formToolkit, Locale locale, String timezone) {
+	public static Control create(Composite composite, MField field, int row, int column, FormToolkit formToolkit, Locale locale, String timezone,
+			MPerspective perspective) {
 
 		String labelText = field.getLabel() == null ? "" : field.getLabel();
 		Label label = formToolkit.createLabel(composite, labelText, SWT.RIGHT);
@@ -74,7 +78,10 @@ public class ShortDateField {
 			}
 		});
 
-		field.setValueAccessor(new ShortDateValueAccessor(field, text));
+		IEclipseContext context = perspective.getContext();
+		ShortDateValueAccessor valueAccessor = new ShortDateValueAccessor(field, text);
+		ContextInjectionFactory.inject(valueAccessor, context);
+		field.setValueAccessor(valueAccessor);
 
 		FormData labelFormData = new FormData();
 		FormData textFormData = new FormData();

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/ShortTimeField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/ShortTimeField.java
@@ -78,6 +78,7 @@ public class ShortTimeField {
 			}
 		});
 
+		// ValueAccessor in den Context injecten, damit IStylingEngine über @Inject verfügbar ist (in AbstractValueAccessor)
 		IEclipseContext context = perspective.getContext();
 		ShortTimeValueAccessor valueAccessor = new ShortTimeValueAccessor(field, text);
 		ContextInjectionFactory.inject(valueAccessor, context);

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/ShortTimeField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/ShortTimeField.java
@@ -17,6 +17,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.nebula.widgets.opal.textassist.TextAssist;
 import org.eclipse.nebula.widgets.opal.textassist.TextAssistContentProvider;
 import org.eclipse.swt.SWT;
@@ -40,8 +43,8 @@ public class ShortTimeField {
 		throw new IllegalStateException("Utility class");
 	}
 
-	public static Control create(Composite composite, MField field, int row, int column, FormToolkit formToolkit,
-			Locale locale, String timezone) {
+	public static Control create(Composite composite, MField field, int row, int column, FormToolkit formToolkit, Locale locale, String timezone,
+			MPerspective perspective) {
 
 		String labelText = field.getLabel() == null ? "" : field.getLabel();
 		Label label = formToolkit.createLabel(composite, labelText, SWT.RIGHT);
@@ -57,8 +60,7 @@ public class ShortTimeField {
 					field.setValue(null, true);
 				} else {
 					LocalTime localTime = LocalTime.ofInstant(time, ZoneId.of("UTC"));
-					result.add(
-							localTime.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(locale)));
+					result.add(localTime.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(locale)));
 					field.setValue(new Value(time), true);
 				}
 				return result;
@@ -66,8 +68,7 @@ public class ShortTimeField {
 
 		};
 		TextAssist text = new TextAssist(composite, SWT.BORDER, contentProvider);
-		text.setMessage(
-				LocalTime.of(23, 59).format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(locale)));
+		text.setMessage(LocalTime.of(23, 59).format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(locale)));
 		text.setNumberOfLines(1);
 		text.setData(TRANSLATE_LOCALE, locale);
 		text.addFocusListener(new FocusAdapter() {
@@ -77,7 +78,10 @@ public class ShortTimeField {
 			}
 		});
 
-		field.setValueAccessor(new ShortTimeValueAccessor(field, text));
+		IEclipseContext context = perspective.getContext();
+		ShortTimeValueAccessor valueAccessor = new ShortTimeValueAccessor(field, text);
+		ContextInjectionFactory.inject(valueAccessor, context);
+		field.setValueAccessor(valueAccessor);
 
 		FormData labelFormData = new FormData();
 		FormData textFormData = new FormData();

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/TextField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/TextField.java
@@ -8,6 +8,9 @@ import static aero.minova.rcp.rcp.fields.FieldUtil.MARGIN_TOP;
 import static aero.minova.rcp.rcp.fields.FieldUtil.TEXT_WIDTH;
 import static aero.minova.rcp.rcp.fields.FieldUtil.TRANSLATE_PROPERTY;
 
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusAdapter;
 import org.eclipse.swt.events.FocusEvent;
@@ -29,7 +32,7 @@ public class TextField {
 		throw new IllegalStateException("Utility class");
 	}
 
-	public static Control create(Composite composite, MField field, int row, int column, FormToolkit formToolkit) {
+	public static Control create(Composite composite, MField field, int row, int column, FormToolkit formToolkit, MPerspective perspective) {
 
 		String labelText = field.getLabel() == null ? "" : field.getLabel();
 		Label label = formToolkit.createLabel(composite, labelText, SWT.RIGHT);
@@ -59,7 +62,10 @@ public class TextField {
 			}
 		});
 
-		field.setValueAccessor(new TextValueAccessor(field, text));
+		IEclipseContext context = perspective.getContext();
+		TextValueAccessor valueAccessor = new TextValueAccessor(field, text);
+		ContextInjectionFactory.inject(valueAccessor, context);
+		field.setValueAccessor(valueAccessor);
 
 		FormData labelFormData = new FormData();
 		FormData textFormData = new FormData();

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/TextField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/TextField.java
@@ -41,7 +41,7 @@ public class TextField {
 		int style = SWT.BORDER;
 		if (field.getNumberRowsSpanned() > 1) {
 			// Maskenentwickler hat mehrzeilige Eingabe definiert
-			style |= SWT.MULTI;
+			style |= SWT.MULTI | SWT.WRAP;
 		}
 		Text text = formToolkit.createText(composite, "", style);
 		text.addFocusListener(new FocusAdapter() {

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/TextField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/TextField.java
@@ -62,6 +62,7 @@ public class TextField {
 			}
 		});
 
+		// ValueAccessor in den Context injecten, damit IStylingEngine über @Inject verfügbar ist (in AbstractValueAccessor)
 		IEclipseContext context = perspective.getContext();
 		TextValueAccessor valueAccessor = new TextValueAccessor(field, text);
 		ContextInjectionFactory.inject(valueAccessor, context);

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/SaveDetailHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/SaveDetailHandler.java
@@ -1,34 +1,59 @@
 package aero.minova.rcp.rcp.handlers;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
+import org.eclipse.e4.core.di.annotations.CanExecute;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.services.events.IEventBroker;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
+import org.eclipse.e4.ui.model.application.ui.basic.MPart;
+import org.eclipse.e4.ui.services.IServiceConstants;
+import org.eclipse.e4.ui.workbench.UIEvents;
 
 import aero.minova.rcp.constants.Constants;
+import aero.minova.rcp.model.event.ValueChangeEvent;
+import aero.minova.rcp.model.event.ValueChangeListener;
+import aero.minova.rcp.model.form.MDetail;
+import aero.minova.rcp.model.form.MField;
+import aero.minova.rcp.rcp.parts.WFCDetailPart;
 
-public class SaveDetailHandler {
+public class SaveDetailHandler implements ValueChangeListener {
 
 	@Inject
 	IEventBroker broker;
 
-	/*
-	 * @CanExecute public boolean canExecute(MPart mpart) { // TODO
-	 * System.out.println("TODO canExecute"); return true; }
-	 */
+	boolean firstCall = true;
 
-	// Sucht die aktiven Controls aus der XMLDetailPart und baut anhand deren Werte
-	// eine Abfrage an den CAS zusammen. Anhand eines gegebenen oder nicht gegebenen
-	// KeyLongs wird zwischen update und neuem Eintrag unterschieden
+	@Inject
+	MPart part;
+
 	@Execute
 	public void execute(@Optional MPerspective perspective) {
-		if (perspective == null) {
-			// TODO Info an den Benutzer
-			return;
-		}
 		broker.post(Constants.BROKER_SAVEENTRY, perspective);
+	}
 
+	@CanExecute
+	public boolean canExecute(MPart part, @Named(IServiceConstants.ACTIVE_SELECTION) @Optional Object selection) {
+		if (part.getObject() instanceof WFCDetailPart) {
+			MDetail detail = ((WFCDetailPart) part.getObject()).getDetail();
+
+			// Handler als Listener hinzufügen, damit auf Änderungen reagiert werden kann
+			if (firstCall) {
+				for (MField f : detail.getFields()) {
+					f.addValueChangeListener(this);
+				}
+			}
+			firstCall = false;
+
+			return detail.allFieldsValid();
+		}
+		return false;
+	}
+
+	@Override
+	public void valueChange(ValueChangeEvent evt) {
+		broker.send(UIEvents.REQUEST_ENABLEMENT_UPDATE_TOPIC, "aero.minova.rcp.rcp.handledtoolitem.save");
 	}
 }

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/SaveDetailHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/SaveDetailHandler.java
@@ -54,6 +54,7 @@ public class SaveDetailHandler implements ValueChangeListener {
 
 	@Override
 	public void valueChange(ValueChangeEvent evt) {
+		// canExecute() Methode wird aufgerufen
 		broker.send(UIEvents.REQUEST_ENABLEMENT_UPDATE_TOPIC, "aero.minova.rcp.rcp.handledtoolitem.save");
 	}
 }

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCDetailPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCDetailPart.java
@@ -318,19 +318,19 @@ public class WFCDetailPart extends WFCFormPart {
 
 	private void createField(Composite composite, MField field, int row, int column) {
 		if (field instanceof MBooleanField) {
-			BooleanField.create(composite, field, row, column, formToolkit, locale);
+			BooleanField.create(composite, field, row, column, formToolkit, locale, perspective);
 		} else if (field instanceof MNumberField) {
-			NumberField.create(composite, (MNumberField) field, row, column, formToolkit, locale);
+			NumberField.create(composite, (MNumberField) field, row, column, formToolkit, locale, perspective);
 		} else if (field instanceof MDateTimeField) {
-			DateTimeField.create(composite, field, row, column, formToolkit, locale, timezone);
+			DateTimeField.create(composite, field, row, column, formToolkit, locale, timezone, perspective);
 		} else if (field instanceof MShortDateField) {
-			ShortDateField.create(composite, field, row, column, formToolkit, locale, timezone);
+			ShortDateField.create(composite, field, row, column, formToolkit, locale, timezone, perspective);
 		} else if (field instanceof MShortTimeField) {
-			ShortTimeField.create(composite, field, row, column, formToolkit, locale, timezone);
+			ShortTimeField.create(composite, field, row, column, formToolkit, locale, timezone, perspective);
 		} else if (field instanceof MLookupField) {
-			LookupField.create(composite, field, row, column, formToolkit, perspective, locale);
+			LookupField.create(composite, field, row, column, formToolkit, locale, perspective);
 		} else if (field instanceof MTextField) {
-			TextField.create(composite, field, row, column, formToolkit);
+			TextField.create(composite, field, row, column, formToolkit, perspective);
 		}
 	}
 


### PR DESCRIPTION
Pflichtfelder (closes #426):
- Pflichtfelder werden farblich hervorgehoben, bis sie ausgefüllt sind
- Es kann nur gespeichert werden, wenn alle Pflichtfelder ausgefüllt sind

Read-Only Felder (closes #472):
- Read-Only Felder werden grau angezeigt
- Sie können nicht bearbeitet werden

Textfelder (closes #302):
- Maximallänge wird aus .xml ausgelesen
- Ist der Inhalt länger als die Maximallänge wird das Feld rot und es kann nicht gespeichert werden
- Bei Textfeldern über mehrere Zeilen erfolgt automatisch ein Zeilenumbruch am Ende des Feldes

Nummerfelder:
- Wenn in der .xml ein Maximal oder Minimal-Wert definiert ist wird geprüft, dass dieser eingehalten ist
- Bei Über-/Unterschreiten wird das Feld rot und es kann nicht gespeichert werden

