### PR TITLE
Druckeinstellungen

### DIFF
--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
@@ -130,7 +130,7 @@ public class PrintIndexHandler {
 				ILayer layer = indexPart.getBodyLayerStack().getGlazedListsEventLayer();
 				int[] widthsBody = MaxCellBoundsHelper.getPreferredColumnWidths(indexPart.getNattable().getConfigRegistry(),
 						new GCFactory(indexPart.getNattable()), layer, widths);
-				layer = indexPart.getColumnHeaderLayer();
+				layer = indexPart.getColumnHeaderDataLayer();
 				int[] widthsHeader = MaxCellBoundsHelper.getPreferredColumnWidths(indexPart.getNattable().getConfigRegistry(),
 						new GCFactory(indexPart.getNattable()), layer, widths);
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
@@ -196,7 +196,11 @@ public class PrintIndexHandler {
 		}
 
 		generatePDF(url_pdf, url_xml, url_xsl);
-		showFile(url_pdf.toString(), null);
+		if (disablePreview || System.getProperty("os.name").startsWith("Win")) {
+			showFile(url_pdf.toString(), null);
+		} else {
+			showFile(url_pdf.toString(), checkPreview(window, modelService, partService, preview));
+		}
 	}
 
 	private boolean isColumnEmpty(Integer i, SortedList<Row> rows) {
@@ -502,7 +506,6 @@ public class PrintIndexHandler {
 	 * @since 11.0.0
 	 */
 	protected static Preview checkPreview(MWindow window, EModelService modelService, EPartService partService, Preview preview) {
-		// Hier erstaml nur Ohne Preview öffnen!
 		if (preview == null) {
 			// Wir suchen mal nach dem Druck-Part und aktivieren ihn
 			MPart previewPart = (MPart) modelService.find(Preview.PART_ID, window);
@@ -515,7 +518,6 @@ public class PrintIndexHandler {
 		} else {
 			preview.clear();
 		}
-		preview = null;
 		return preview;
 	}
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
@@ -72,6 +72,9 @@ public class PrintIndexHandler {
 	private IEventBroker broker;
 
 	@Inject
+	private EPartService ePartService;
+
+	@Inject
 	@Preference(nodePath = ApplicationPreferences.PREFERENCES_NODE, value = ApplicationPreferences.CREATE_XML_XS)
 	public boolean createXmlXsl;
 	@Inject
@@ -159,7 +162,7 @@ public class PrintIndexHandler {
 			ReportConfiguration rConfig = new ReportConfiguration();
 
 			try {
-				TableXSLCreator tableCreator = new TableXSLCreator(translationService, indexPart, this);
+				TableXSLCreator tableCreator = new TableXSLCreator(translationService, indexPart, this, ePartService);
 				xslString = tableCreator.createXSL(xmlRootTag, title, sortedDataList, colConfig, rConfig, path_reports, groupByIndicesReordered);
 			} catch (ReportCreationException e) {
 				e.printStackTrace();

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
@@ -1,5 +1,6 @@
 package aero.minova.rcp.rcp.handlers;
 
+import java.awt.Font;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -38,6 +39,7 @@ import org.eclipse.nebula.widgets.nattable.reorder.ColumnReorderLayer;
 import org.eclipse.nebula.widgets.nattable.resize.MaxCellBoundsHelper;
 import org.eclipse.nebula.widgets.nattable.summaryrow.FixedSummaryRowLayer;
 import org.eclipse.nebula.widgets.nattable.util.GCFactory;
+import org.eclipse.swt.graphics.FontData;
 
 import aero.minova.rcp.constants.Constants;
 import aero.minova.rcp.dataservice.IDataService;
@@ -150,7 +152,7 @@ public class PrintIndexHandler {
 					width = widths[i1];
 				}
 				boolean vis = !hideEmptyCols || !isColumnEmpty(i1, sortedDataList);
-				colConfig.add(new ColumnInfo(data.getColumns().get(i1), width, vis));
+				colConfig.add(new ColumnInfo(data.getColumns().get(i1), width, vis, i));
 
 				if (groupByIndices.contains(i1)) {
 					groupByIndicesReordered.add(i);
@@ -160,14 +162,15 @@ public class PrintIndexHandler {
 
 			ReportConfiguration rConfig = new ReportConfiguration();
 			if (indexFont != null) {
-				String[] indexSplit = indexFont.split("\\|");
+				FontData fontData = new FontData(indexFont);
 				int fontsize = 8;
 				try {
-					fontsize = (int) Double.parseDouble(indexSplit[2]);
+					fontsize = fontData.getHeight();
 				} catch (Exception e) {}
 				rConfig.setProp("FontSizeCriteria", fontsize + "");
 				rConfig.setProp("FontSizeCell", fontsize + "");
-				rConfig.setProp("FontFamily", indexSplit[1]);
+				rConfig.setProp("FontFamily", fontData.getName());
+				rConfig.guiFont = new Font(fontData.getName(), Font.PLAIN, fontsize);
 			}
 
 			try {

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
@@ -196,6 +196,7 @@ public class PrintIndexHandler {
 		}
 
 		generatePDF(url_pdf, url_xml, url_xsl);
+		// Auf Windows gibt es Probleme mit der internen Vorschau, deshalb immer deaktiviert
 		if (disablePreview || System.getProperty("os.name").startsWith("Win")) {
 			showFile(url_pdf.toString(), null);
 		} else {

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
@@ -163,7 +163,7 @@ public class PrintIndexHandler {
 
 			try {
 				TableXSLCreator tableCreator = new TableXSLCreator(translationService, indexPart, this, ePartService);
-				xslString = tableCreator.createXSL(xmlRootTag, title, sortedDataList, colConfig, rConfig, path_reports, groupByIndicesReordered);
+				xslString = tableCreator.createXSL(xmlRootTag, title, colConfig, rConfig, path_reports, groupByIndicesReordered);
 			} catch (ReportCreationException e) {
 				e.printStackTrace();
 			}

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
@@ -159,6 +159,16 @@ public class PrintIndexHandler {
 			}
 
 			ReportConfiguration rConfig = new ReportConfiguration();
+			if (indexFont != null) {
+				String[] indexSplit = indexFont.split("\\|");
+				int fontsize = 8;
+				try {
+					fontsize = (int) Double.parseDouble(indexSplit[2]);
+				} catch (Exception e) {}
+				rConfig.setProp("FontSizeCriteria", fontsize + "");
+				rConfig.setProp("FontSizeCell", fontsize + "");
+				rConfig.setProp("FontFamily", indexSplit[1]);
+			}
 
 			try {
 				TableXSLCreator tableCreator = new TableXSLCreator(translationService, indexPart, this, ePartService);

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
@@ -143,7 +143,7 @@ public class PrintIndexHandler {
 				}
 			}
 
-			// ColumnInfo erstellen und evtl Gruppierungsspaten entfernen
+			// ColumnInfo erstellen
 			List<ColumnInfo> colConfig = new ArrayList<>();
 			int i = 0;
 			for (Integer i1 : columnReorderLayer.getColumnIndexOrder()) {
@@ -174,7 +174,7 @@ public class PrintIndexHandler {
 			}
 
 			try {
-				TableXSLCreator tableCreator = new TableXSLCreator(translationService, indexPart, this, ePartService);
+				TableXSLCreator tableCreator = new TableXSLCreator(translationService, this, ePartService);
 				xslString = tableCreator.createXSL(xmlRootTag, title, colConfig, rConfig, path_reports, groupByIndicesReordered);
 			} catch (ReportCreationException e) {
 				e.printStackTrace();

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCIndexPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCIndexPart.java
@@ -157,6 +157,8 @@ public class WFCIndexPart extends WFCFormPart {
 
 	private FixedSummaryRowLayer summaryRowLayer;
 
+	private DefaultColumnHeaderDataLayer columnHeaderDataLayer;
+
 	@PostConstruct
 	public void createComposite(Composite parent, EModelService modelService) {
 		new FormToolkit(parent.getDisplay());
@@ -369,15 +371,15 @@ public class WFCIndexPart extends WFCFormPart {
 		// build the column header layer
 		IDataProvider columnHeaderDataProvider = new DefaultColumnHeaderDataProvider(columnPropertyAccessor.getPropertyNames(),
 				columnPropertyAccessor.getTableHeadersMap());
-		DataLayer columnHeaderDataLayer = new DefaultColumnHeaderDataLayer(columnHeaderDataProvider);
-		columnHeaderLayer = new ColumnHeaderLayer(columnHeaderDataLayer, bodyLayerStack, bodyLayerStack.getSelectionLayer());
+		columnHeaderDataLayer = new DefaultColumnHeaderDataLayer(columnHeaderDataProvider);
+		columnHeaderLayer = new ColumnHeaderLayer(getColumnHeaderDataLayer(), bodyLayerStack, bodyLayerStack.getSelectionLayer());
 
 		sortHeaderLayer = new SortHeaderLayer<>(columnHeaderLayer,
-				new GlazedListsSortModel<>(bodyLayerStack.getSortedList(), columnPropertyAccessor, configRegistry, columnHeaderDataLayer), false);
+				new GlazedListsSortModel<>(bodyLayerStack.getSortedList(), columnPropertyAccessor, configRegistry, getColumnHeaderDataLayer()), false);
 		// Eigenen Sort-Comparator auf alle Spalten registrieren (Verhindert Fehler bei Zeilen, die keinen von- oder bis-Wert haben)
-		ColumnOverrideLabelAccumulator labelAccumulator = new ColumnOverrideLabelAccumulator(columnHeaderDataLayer);
-		columnHeaderDataLayer.setConfigLabelAccumulator(labelAccumulator);
-		for (int i = 0; i < columnHeaderDataLayer.getColumnCount(); i++) {
+		ColumnOverrideLabelAccumulator labelAccumulator = new ColumnOverrideLabelAccumulator(getColumnHeaderDataLayer());
+		getColumnHeaderDataLayer().setConfigLabelAccumulator(labelAccumulator);
+		for (int i = 0; i < getColumnHeaderDataLayer().getColumnCount(); i++) {
 			labelAccumulator.registerColumnOverrides(i, Constants.COMPARATOR_LABEL);
 		}
 		configRegistry.registerConfigAttribute(SortConfigAttributes.SORT_COMPARATOR, new CustomComparator(), DisplayMode.NORMAL, Constants.COMPARATOR_LABEL);
@@ -419,7 +421,7 @@ public class WFCIndexPart extends WFCFormPart {
 		SelectionLayer selectionLayer = bodyLayerStack.getSelectionLayer();
 		selectionLayer.addConfiguration(new DefaultRowSelectionLayerConfiguration());
 
-		CopyDataCommandHandler copyHandler = new CopyDataCommandHandler(selectionLayer, columnHeaderDataLayer, rowHeaderDataLayer);
+		CopyDataCommandHandler copyHandler = new CopyDataCommandHandler(selectionLayer, getColumnHeaderDataLayer(), rowHeaderDataLayer);
 		copyHandler.setCopyFormattedText(true);
 		gridLayer.registerCommandHandler(copyHandler);
 
@@ -821,5 +823,9 @@ public class WFCIndexPart extends WFCFormPart {
 
 	public FixedSummaryRowLayer getSummaryRowLayer() {
 		return summaryRowLayer;
+	}
+
+	public DefaultColumnHeaderDataLayer getColumnHeaderDataLayer() {
+		return columnHeaderDataLayer;
 	}
 }

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/print/ColumnInfo.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/print/ColumnInfo.java
@@ -44,6 +44,9 @@ public class ColumnInfo {
 	/** Aktuelle Breite der Column in Pixel */
 	public int width;
 
+	/** Aktueller Index der Column in der Nattable **/
+	public int index;
+
 	/**
 	 * Die Breite der Column kann für den Druck optimiert werden.<br>
 	 * Falls bereits geschehen, steht die optimierte Breite in diesem Feld.
@@ -65,6 +68,11 @@ public class ColumnInfo {
 		this.width = width;
 		this.column = field;
 		this.visible = visible;
+	}
+
+	public ColumnInfo(Column field, int width, boolean visible, int index) {
+		this(field, width, visible);
+		this.index = index;
 	}
 
 	/**

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/print/ReportConfiguration.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/print/ReportConfiguration.java
@@ -30,7 +30,7 @@ public class ReportConfiguration extends CommonPrint {
 	 * Falls verfügbar, haben wir hier den von der GUI verwendeten Font (sonst Standardfont)<br>
 	 * wird verwendet, um Breiten automatisch zu berechnen
 	 */
-	public final Font guiFont;
+	public Font guiFont;
 
 	public final String xslFontFamily;
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/print/ReportConfiguration.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/print/ReportConfiguration.java
@@ -122,6 +122,10 @@ public class ReportConfiguration extends CommonPrint {
 		return (toRet == null ? def : toRet);
 	}
 
+	public void setProp(String key, String val) {
+		props.put(key, val);
+	}
+
 	/**
 	 * berechnet die verfügbare Breite der Seite in mm (abz. Rand)
 	 *

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/print/TableXSLCreator.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/print/TableXSLCreator.java
@@ -60,8 +60,10 @@ public class TableXSLCreator extends CommonPrint {
 		// Gruppierungsspalten entfernen
 		if (printHandler.hideGroupCols) {
 			List<ColumnInfo> toRemove = new ArrayList<ColumnInfo>();
-			for (Integer i : groupByIndicesReordered) {
-				toRemove.add(cols.get(i));
+			for (ColumnInfo colInf : cols) {
+				if (groupByIndicesReordered.contains(colInf.index)) {
+					toRemove.add(colInf);
+				}
 			}
 			cols.removeAll(toRemove);
 		}
@@ -183,7 +185,7 @@ public class TableXSLCreator extends CommonPrint {
 		}
 
 		dColSize *= conf.PIXEL_SIZE_MM;
-		dColSize += conf.CELL_PADDING_MM;
+		dColSize += conf.CELL_PADDING_MM * 2;
 
 		if (col.column == null || isOptimized) {
 			// WIS: empty field oder optimizeFieldWidth schon geschehen wir haben die Breite schon so berechnet, dass es stimmt darf also nicht noch mal
@@ -197,7 +199,7 @@ public class TableXSLCreator extends CommonPrint {
 		// Umrechnung Schriftgröße
 		double fontFactor = 1;
 		if (!conf.standardFont.equals(conf.guiFont)) {
-			fontFactor = conf.standardFont.getSize2D() / conf.guiFont.getSize2D();
+			fontFactor = conf.guiFont.getSize2D() / conf.standardFont.getSize2D();
 		}
 
 		final int iColSize = (int) (dColSize * dpiFactor * fontFactor);
@@ -238,7 +240,10 @@ public class TableXSLCreator extends CommonPrint {
 					continue;
 				}
 				final FilterValue v = (FilterValue) v1;
-				final String value = v.getOperatorValue() + " " + v.getFilterValue().getValueString(Locale.getDefault());
+				String value = v.getOperatorValue();
+				if (v.getFilterValue() != null) {
+					value += " " + v.getFilterValue().getValueString(Locale.getDefault());
+				}
 
 				searchCriteria = getTemplate("SearchCriteria");
 				searchCriteriaText = (first ? "" : (and.getBooleanValue() ? "& " : "| "));
@@ -270,7 +275,10 @@ public class TableXSLCreator extends CommonPrint {
 					continue;
 				}
 				final FilterValue v = (FilterValue) v1;
-				final String value = v.getOperatorValue() + " " + v.getFilterValue().getValueString(Locale.getDefault());
+				String value = v.getOperatorValue();
+				if (v.getFilterValue() != null) {
+					value += " " + v.getFilterValue().getValueString(Locale.getDefault());
+				}
 
 				searchCriteriaText = (first ? "" : (and.getBooleanValue() ? "& " : "| "));
 				searchCriteriaText += value;

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/print/TableXSLCreator.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/print/TableXSLCreator.java
@@ -16,7 +16,6 @@ import aero.minova.rcp.model.Row;
 import aero.minova.rcp.model.Table;
 import aero.minova.rcp.model.Value;
 import aero.minova.rcp.rcp.handlers.PrintIndexHandler;
-import aero.minova.rcp.rcp.parts.WFCIndexPart;
 import aero.minova.rcp.rcp.parts.WFCSearchPart;
 import aero.minova.rcp.rcp.print.ReportCreationException.Cause;
 import aero.minova.rcp.util.IOUtil;
@@ -30,7 +29,7 @@ public class TableXSLCreator extends CommonPrint {
 	// Templates
 	private static HashMap<String, String> templates = new HashMap<>();
 
-	public TableXSLCreator(TranslationService translationService2, WFCIndexPart indexPart, PrintIndexHandler printHandler, EPartService ePartService) {
+	public TableXSLCreator(TranslationService translationService2, PrintIndexHandler printHandler, EPartService ePartService) {
 		this.translationService = translationService2;
 		this.printHandler = printHandler;
 		this.searchPart = (WFCSearchPart) ePartService.findPart("aero.minova.rcp.rcp.part.search").getObject();

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/NatTableUtil.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/NatTableUtil.java
@@ -10,17 +10,16 @@ public class NatTableUtil {
 
 	public static void resize(NatTable natTable) {
 		for (int i = 0; i < natTable.getColumnCount(); i++) {
-			InitializeAutoResizeColumnsCommand columnCommand = new InitializeAutoResizeColumnsCommand(natTable, i,
-					natTable.getConfigRegistry(), new GCFactory(natTable));
+			InitializeAutoResizeColumnsCommand columnCommand = new InitializeAutoResizeColumnsCommand(natTable, i, natTable.getConfigRegistry(),
+					new GCFactory(natTable));
 			natTable.doCommand(columnCommand);
 		}
 
-		for (int i = 0; i < natTable.getColumnCount(); i++) {
-			InitializeAutoResizeRowsCommand rowCommand = new InitializeAutoResizeRowsCommand(natTable, i,
-					natTable.getConfigRegistry(), new GCFactory(natTable));
+		for (int i = 0; i < natTable.getRowCount(); i++) {
+			InitializeAutoResizeRowsCommand rowCommand = new InitializeAutoResizeRowsCommand(natTable, i, natTable.getConfigRegistry(),
+					new GCFactory(natTable));
 			natTable.doCommand(rowCommand);
 		}
-
 	}
 
 	public static void refresh(NatTable natTable) {

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/PDFGenerator.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/PDFGenerator.java
@@ -1,9 +1,10 @@
 package aero.minova.rcp.rcp.util;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Map;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
@@ -24,23 +25,15 @@ import org.xml.sax.SAXException;
  */
 public class PDFGenerator {
 
-	private final Map<String, String> configuration;
+	public PDFGenerator() {}
 
-	public PDFGenerator(Map<String, String> configuration) {
-        this.configuration = configuration;
-    }
-
-	public void createPdfFile(String xmlDataFile, String templateFile, OutputStream pdfOutputStream) throws IOException, SAXException, TransformerException {
+	public void createPdfFile(String xmlDataString, String templateString, OutputStream pdfOutputStream)
+			throws IOException, SAXException, TransformerException {
 		System.out.println("Create pdf file ...");
 		File tempFile = File.createTempFile("fop-" + System.currentTimeMillis(), ".pdf");
 
-		// holds references to configuration information and cached data
-		// reuse this instance if you plan to render multiple documents
-
 		FopFactory fopFactory = FopFactory.newInstance();
-
 		fopFactory.setBaseURL(new File(".").toURI().toURL().toString());
-
 		FOUserAgent userAgent = fopFactory.newFOUserAgent();
 
 		try {
@@ -49,13 +42,14 @@ public class PDFGenerator {
 
 			// Load template
 			TransformerFactory transformerFactory = TransformerFactory.newInstance();
-			Transformer transformer = transformerFactory.newTransformer(new StreamSource(new File(templateFile)));
+			Transformer transformer = transformerFactory
+					.newTransformer(new StreamSource(new ByteArrayInputStream(templateString.getBytes(StandardCharsets.UTF_8))));
 
 			// Set value of parameters in stylesheet
 			transformer.setParameter("version", "1.0");
 
 			// Input for XSLT transformations
-			Source xmlSource = new StreamSource(new File(xmlDataFile));
+			Source xmlSource = new StreamSource(new ByteArrayInputStream(xmlDataString.getBytes(StandardCharsets.UTF_8)));
 
 			Result result = new SAXResult(fop.getDefaultHandler());
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/Lookup.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/Lookup.java
@@ -273,7 +273,7 @@ public class Lookup extends Composite {
 
 				final String string = text.getText();
 				if (string.length() == 0) {
-					popup.setVisible(false);
+					// popup.setVisible(false);
 					return;
 				}
 				showAllElements(string);

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/Lookup.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/Lookup.java
@@ -273,7 +273,7 @@ public class Lookup extends Composite {
 
 				final String string = text.getText();
 				if (string.length() == 0) {
-					// popup.setVisible(false);
+					popup.setVisible(false);
 					return;
 				}
 				showAllElements(string);


### PR DESCRIPTION
Die Einstellungen für Drucken können benutzt werden:

- XML + XSL erstellen
- Schriftart Inhaltsverzeichnis: Die Schriftgröße in den Tabellen ändert sich entsprechend
- Breite optimieren: Spalten haben automatisch die benötigte Breite
- Leere Spalten verbergen: Spalten ohne Werte oder zu schmale Spalten werden verborgen
- Gruppenspalten verbergen: Wenn nach einer Spalte gruppiert wird erscheint diese nicht in den Tabellen
- Suchkriterien verbergen: Die Suchkriterien können in den Tabellenüberschriften angezeigt werden
- Interne Vorschau deaktivieren: Auf Windows ist die interne Vorschau immer deaktiviert

closes #435