### PR TITLE
InstanceLocation wird nicht gesetzt wenn Anmeldedaten ungültig sind

### DIFF
--- a/bundles/aero.minova.rcp.workspace/src/aero/minova/rcp/workspace/handler/SpringBootWorkspace.java
+++ b/bundles/aero.minova.rcp.workspace/src/aero/minova/rcp/workspace/handler/SpringBootWorkspace.java
@@ -90,8 +90,8 @@ public class SpringBootWorkspace extends WorkspaceHandler {
 
 	@Override
 	public void open() throws WorkspaceException {
-		if (!getPassword().isEmpty() && !getPassword().equals("xxxxxxxxxxxxxxxxxxxx")) {
-			// Manuell wurde hier das Psswort eingetragten / geändert
+		if (!getPassword().equals("xxxxxxxxxxxxxxxxxxxx")) {
+			// Entwender das Passwort ist null/leer oder es wurde manuell eingetragten / geändert
 			checkCredentials(getPassword());
 		}
 		if (!Platform.getInstanceLocation().isSet()) {

--- a/bundles/aero.minova.rcp.workspace/src/aero/minova/rcp/workspace/handler/SpringBootWorkspace.java
+++ b/bundles/aero.minova.rcp.workspace/src/aero/minova/rcp/workspace/handler/SpringBootWorkspace.java
@@ -90,10 +90,27 @@ public class SpringBootWorkspace extends WorkspaceHandler {
 
 	@Override
 	public void open() throws WorkspaceException {
+
+		// Zuerst überprüfen, ob die Anmeldedaten gültig sind. Damit wird verhindert, dass sich das Passwort nicht ändern lässt, weil die Instance Location
+		// schon gesetzt ist
 		if (!getPassword().equals("xxxxxxxxxxxxxxxxxxxx")) {
 			// Entwender das Passwort ist null/leer oder es wurde manuell eingetragten / geändert
 			checkCredentials(getPassword());
+		} else {
+			// Passwort aus dem Store benutzen
+			for (ISecurePreferences store : WorkspaceAccessPreferences.getSavedWorkspaceAccessData(logger)) {
+				try {
+					if (getProfile().equals(store.get(WorkspaceAccessPreferences.PROFILE, null))) {
+						// ausgelesendes Passwort vom Store checken
+						checkCredentials(store.get(WorkspaceAccessPreferences.PASSWORD, null));
+						break;
+					}
+				} catch (StorageException e) {
+					e.printStackTrace();
+				}
+			}
 		}
+
 		if (!Platform.getInstanceLocation().isSet()) {
 			// 1. Auslesen aus dem Store, ggf. Setzen
 			String defaultPath = System.getProperty("user.home");
@@ -128,7 +145,6 @@ public class SpringBootWorkspace extends WorkspaceHandler {
 						if (getPassword().isEmpty() || getPassword().equals("xxxxxxxxxxxxxxxxxxxx")) {
 							// ausgelesendes Passwort vom Store nehmen
 							workspaceData.setPassword(store.get(WorkspaceAccessPreferences.PASSWORD, null));
-
 						} else {
 							// ausgelesendes Passwort vom Dialog in den Store setzen
 							store.put(WorkspaceAccessPreferences.PASSWORD, getPassword(), true);


### PR DESCRIPTION
Anmeldedaten werden zuerst geprüft, sodass bei ungültigen Daten die Instancelocation nicht gesetzt wird.
Damit können falsche Passwörter in Profilen verbessert und gespeichter werden.

Closes #388 