### PR TITLE
Generierte Menus werden nicht mehr

### DIFF
--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/processor/MenuProcessor.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/processor/MenuProcessor.java
@@ -80,6 +80,7 @@ public class MenuProcessor {
 	private void createMenu(MenuType menu_MDI, MMenu menu, HashMap<String, Action> actions_MDI,
 			EModelService modelService, MApplication mApplication) {
 		MMenu menuGen = modelService.createModelElement(MMenu.class);
+		menuGen.getPersistedState().put("persistState", String.valueOf(false));
 		// TODO Übersetzung einbauen
 		menuGen.setLabel(menu_MDI.getText());
 


### PR DESCRIPTION
Durch das Setzen von persistState auf false, werden die generierten
Menueinträge nicht mehr abgespeichert.

Wirkt sich nur auf neu erzeugten Menueinträge aus!!!! Menueinträge, die
vor diesem Setting generiert wurden, bleiben stehen bzw. werden mit dem
Flag -clearPersistedState entfernt.

Fixes #500