### PR TITLE
Maskenname und ID im PerspectiveSwitcher trennen

### DIFF
--- a/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
+++ b/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
@@ -84,6 +84,17 @@ public class Constants {
 	public static final String CSS_READONLY = "ReadOnly";
 
 	/**
+	 * Id for command parameter "Perspective ID" (value is
+	 * <code>"org.eclipse.e4.ui.perspectives.parameters.perspectiveId"</code>).
+	 */
+
+	public static final String FORM_NAME = "aero.minova.rcp.perspectiveswitcher.parameters.formName"; //$NON-NLS-1$
+
+	public static final String FORM_ID = "aero.minova.rcp.perspectiveswitcher.parameters.formId"; //$NON-NLS-1$
+
+	public static final String FORM_LABEL = "aero.minova.rcp.perspectiveswitcher.parameters.perspectiveLabel"; //$NON-NLS-1$
+
+	/**
 	 * Hier werden Standard-Einstellungen definiert, die wirklich oft genutzt werden
 	 *
 	 * @author dombrovski

--- a/bundles/aero.minova.rcp.perspectiveswitcher/META-INF/MANIFEST.MF
+++ b/bundles/aero.minova.rcp.perspectiveswitcher/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: org.eclipse.e4.core.contexts,
  org.eclipse.e4.ui.services,
  org.eclipse.e4.core.services,
  org.eclipse.core.commands,
- org.eclipse.ui.forms
+ org.eclipse.ui.forms,
+ aero.minova.rcp.constant;bundle-version="12.0.15"
 Export-Package: aero.minova.rcp.perspectiveswitcher.commands,
  aero.minova.rcp.perspectiveswitcher.handler

--- a/bundles/aero.minova.rcp.perspectiveswitcher/src/aero/minova/rcp/perspectiveswitcher/handler/SwitchPerspectiveHandler.java
+++ b/bundles/aero.minova.rcp.perspectiveswitcher/src/aero/minova/rcp/perspectiveswitcher/handler/SwitchPerspectiveHandler.java
@@ -1,7 +1,6 @@
 package aero.minova.rcp.perspectiveswitcher.handler;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -9,21 +8,18 @@ import java.util.logging.Logger;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.eclipse.e4.core.commands.ECommandService;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.di.annotations.Optional;
-import org.eclipse.e4.core.services.events.IEventBroker;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.ui.MElementContainer;
 import org.eclipse.e4.ui.model.application.ui.MUIElement;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
-import org.eclipse.e4.ui.model.application.ui.menu.MHandledMenuItem;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
 
-import aero.minova.rcp.perspectiveswitcher.commands.E4WorkbenchParameterConstants;
+import aero.minova.rcp.constants.Constants;
 
 public class SwitchPerspectiveHandler {
 
@@ -31,27 +27,22 @@ public class SwitchPerspectiveHandler {
 	MApplication application;
 
 	@Inject
-	ECommandService commandService;
-
-	@Inject
 	EPartService partService;
 
 	@Inject
 	EModelService model;
 
-	@Inject
-	IEventBroker broker;
-
 	@Execute
 	public void execute(IEclipseContext context,
-			@Optional @Named(E4WorkbenchParameterConstants.FORM_NAME) String formName,
-			@Optional @Named(E4WorkbenchParameterConstants.COMMAND_PERSPECTIVE_NEW_WINDOW) String newWindow,
-			MWindow window) throws InvocationTargetException, InterruptedException {
-		if (Boolean.parseBoolean(newWindow)) {
-			openNewWindowPerspective(context, formName);
-		} else {
-			openPerspective(context, formName, window, formName);
-		}
+			@Optional @Named(Constants.FORM_NAME) String formName,
+			@Optional @Named(Constants.FORM_ID) String perspectiveId,
+			@Optional @Named(Constants.FORM_LABEL) String perspectiveName, MWindow window) {
+
+		Objects.requireNonNull(formName);
+		Objects.requireNonNull(perspectiveId);
+		Objects.requireNonNull(perspectiveName);
+
+		openPerspective(context, perspectiveId, window, formName, perspectiveName);
 	}
 
 	/**
@@ -60,34 +51,18 @@ public class SwitchPerspectiveHandler {
 	 * @param perspectiveId The perspective to open; must not be <code>null</code>
 	 * @throws ExecutionException If the perspective could not be opened.
 	 */
-	private final void openPerspective(IEclipseContext context, String perspectiveID, MWindow window, String formName) {
+	private final void openPerspective(IEclipseContext context, String perspectiveID, MWindow window, String formName,
+			String perspectiveName) {
 		MApplication application = context.get(MApplication.class);
 		EModelService modelService = context.get(EModelService.class);
-		if (perspectiveID.contains("."))
-			perspectiveID = perspectiveID.substring(0, perspectiveID.indexOf("."));
+
 
 		MUIElement element = modelService.find(perspectiveID, application);
 		if (element == null) {
-			/* MPerspective perspective = */ createNewPerspective(context, perspectiveID, formName);
+			/* MPerspective perspective = */ createNewPerspective(context, perspectiveID, formName, perspectiveName);
 		} else {
 			switchTo(element, perspectiveID, window);
 		}
-	}
-
-	/**
-	 * Opens the specified perspective in a new window.
-	 * 
-	 * @param perspectiveId The perspective to open; must not be <code>null</code>
-	 * @throws ExecutionException If the perspective could not be opened.
-	 */
-	private void openNewWindowPerspective(IEclipseContext context, String perspectiveID) {
-		EModelService modelService = context.get(EModelService.class);
-		EPartService partService = context.get(EPartService.class);
-
-		List<MPerspective> perspectives = modelService.findElements(application, perspectiveID, MPerspective.class,
-				null);
-		partService.switchPerspective(perspectives.get(0));
-
 	}
 
 	/**
@@ -99,11 +74,11 @@ public class SwitchPerspectiveHandler {
 	 * @param perspectiveID
 	 * @return die neue Perspektive
 	 */
-	private MPerspective createNewPerspective(IEclipseContext context, String perspectiveID, String formName) {
+	private MPerspective createNewPerspective(IEclipseContext context, String perspectiveID, String formName,
+			String perspectiveName) {
 		MWindow window = context.get(MWindow.class);
 		EModelService modelService = context.get(EModelService.class);
-		List<MHandledMenuItem> items = model.findElements(window.getMainMenu(), perspectiveID, MHandledMenuItem.class);
-		MHandledMenuItem item = items.get(0);
+
 
 		@SuppressWarnings("unchecked")
 		MElementContainer<MUIElement> perspectiveStack = (MElementContainer<MUIElement>) modelService
@@ -117,8 +92,8 @@ public class SwitchPerspectiveHandler {
 		} else {
 			element.setElementId(perspectiveID);
 			perspective = (MPerspective) element;
-			perspective.getPersistedState().put(E4WorkbenchParameterConstants.FORM_NAME, formName);
-			perspective.setLabel(item.getLabel());
+			perspective.getPersistedState().put(Constants.FORM_NAME, formName);
+			perspective.setLabel(perspectiveName);
 			perspectiveStack.getChildren().add(perspective);
 			switchTo(perspective, perspectiveID, window);
 
@@ -128,10 +103,11 @@ public class SwitchPerspectiveHandler {
 
 	/**
 	 * wechselt zur angegebenen Perspektive, falls das Element eine Perspektive ist
+	 * O
 	 * 
 	 * @param element
 	 */
-	public void switchTo(MUIElement element, @Named(E4WorkbenchParameterConstants.FORM_NAME) String perspectiveID,
+	public void switchTo(MUIElement element, @Named(Constants.FORM_NAME) String perspectiveID,
 			MWindow window) {
 
 		if (element instanceof MPerspective) {

--- a/bundles/aero.minova.rcp.rcp/Application.e4xmi
+++ b/bundles/aero.minova.rcp.rcp/Application.e4xmi
@@ -153,6 +153,8 @@
   <commands xmi:id="_Lwy8UIydEeuboqmDt256_Q" elementId="org.eclipse.ui.edit.undo" commandName="undoCommand"/>
   <commands xmi:id="_4p5JwLufEeqOjqZ1liG0LA" elementId="aero.minova.rcp.rcp.command.openform" commandName="OpenForm">
     <parameters xmi:id="_7dRQULufEeqOjqZ1liG0LA" elementId="aero.minova.rcp.perspectiveswitcher.parameters.formName" name="FormName" optional="false"/>
+    <parameters xmi:id="_CeAmEKzNEeutXsPDGafqQA" elementId="aero.minova.rcp.perspectiveswitcher.parameters.formId" name="Form ID"/>
+    <parameters xmi:id="_EKUHIKzeEeutXsPDGafqQA" elementId="aero.minova.rcp.perspectiveswitcher.parameters.perspectiveLabel" name="Perspective Label"/>
   </commands>
   <commands xmi:id="_Oe_xYMEdEeqyRP6BKwa0Bg" elementId="aero.minova.rcp.rcp.command.closeperspective" commandName="ClosePerspectiveCommand">
     <parameters xmi:id="_bbbLoOxLEeqe7f1c8iuT3A" elementId="aero.minova.rcp.perspectiveswitcher.parameters.formName" name="ClosePerspective"/>

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
@@ -46,6 +46,7 @@ import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 
+import aero.minova.rcp.constants.Constants;
 import aero.minova.rcp.perspectiveswitcher.commands.E4WorkbenchParameterConstants;
 
 @SuppressWarnings("restriction")
@@ -217,8 +218,13 @@ public class PerspectiveControl implements IPerspectiveSwitcherControl {
 
 				@Override
 				public void widgetSelected(SelectionEvent event) {
-					Map<String, String> parameter = Map.of("aero.minova.rcp.perspectiveswitcher.parameters.formName",
-							perspective.getElementId());
+					Map<String, String> parameter = Map.of (//
+							Constants.FORM_NAME, perspective.getElementId(), Constants.FORM_ID,
+							perspective.getElementId(),
+							Constants.FORM_LABEL, perspective.getElementId()
+					//
+					);
+
 					ParameterizedCommand command = commandService.createCommand("aero.minova.rcp.rcp.command.openform",
 							parameter);
 					handlerService.executeHandler(command);
@@ -240,9 +246,7 @@ public class PerspectiveControl implements IPerspectiveSwitcherControl {
 			menu.setData(perspective.getElementId());
 
 			if (perspective.isVisible()) {
-//				if (!"aero.minova.rcp.rcp.perspective.sis".equals(perspective.getElementId())) {
 				addCloseMenuItem(menu, perspectiveId);
-//				}
 			}
 		}
 
@@ -326,14 +330,14 @@ public class PerspectiveControl implements IPerspectiveSwitcherControl {
 	}
 
 	private void removeToolItem(ToolItem item) {
-		if (item == null || item.isDisposed())
+		if (item == null || item.isDisposed()) {
 			return;
+		}
 
 		Image icon = item.getImage();
 		if (icon != null) {
 			item.setImage(null);
 			icon.dispose();
-			icon = null;
 		}
 
 		item.dispose();
@@ -360,7 +364,6 @@ public class PerspectiveControl implements IPerspectiveSwitcherControl {
 
 			if (oldIcon != null) {
 				oldIcon.dispose();
-				oldIcon = null;
 			}
 
 			if (!showShortcutText) {


### PR DESCRIPTION
Form, ID und Label werden jetzt als Parameter für den SwitchPerspective
Handler erwartet. Das PerspectiveControl liefert diese auch mit.