### PR TITLE
Antwortzeit beim Indexladen

### DIFF
--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
@@ -571,7 +571,6 @@ public class DataService implements IDataService {
 
 	@Override
 	public CompletableFuture<List<LookupValue>> resolveLookup(MLookupField field, boolean useCache, Integer keyLong, String keyText) {
-		useCache = false;
 		ArrayList<LookupValue> list = new ArrayList<>();
 		if (field.getLookupTable() != null) {
 			String tableName = field.getLookupTable();

--- a/bundles/aero.minova.workingtime.wizard/src/aero/minova/workingtime/wizard/FillWorkingtimeWizard.java
+++ b/bundles/aero.minova.workingtime.wizard/src/aero/minova/workingtime/wizard/FillWorkingtimeWizard.java
@@ -84,8 +84,9 @@ public class FillWorkingtimeWizard extends MinovaWizard {
 				Display.getDefault().syncExec(() -> {
 					((WizardDialog) getContainer()).close();
 
-					NotificationPopUp notificationPopUp = new NotificationPopUp(Display.getCurrent(), translationService.translate("@msg.DataSaved", null),
-							translationService.translate("@Notification", null), Display.getCurrent().getActiveShell());
+					NotificationPopUp notificationPopUp = new NotificationPopUp(Display.getCurrent(),
+							translationService.translate("@msg.FillWorkingtimeSaved", null), translationService.translate("@Notification", null),
+							Display.getCurrent().getActiveShell());
 					notificationPopUp.open();
 
 					if (autoLoadIndex) {


### PR DESCRIPTION
Beim Auflösen von Lookups können wir den Cache nutzen. Damit muss beim Laden aus dem Index jede Lookup-Option nur einmal angefragt werden, und nachfolgende Anfragen sind wesentlich schneller.

Mit den CTS ergibt sich kein Problem, da die Anruf-Termine trotzdem jedesmal angefragt werden.

closes #603 

Außerdem wird die Nachricht, die beim Speichern von "Arbeitszeit füllen" angezeigt wird, angepasst.