### PR TITLE
Wenn ein Lookup nicht aufgelöst werden kann den Value auf null setzten

### DIFF
--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/LookupValueAccessor.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/LookupValueAccessor.java
@@ -91,15 +91,9 @@ public class LookupValueAccessor extends AbstractValueAccessor {
 
 			CompletableFuture<List<LookupValue>> resolveLookup = dataService.resolveLookup((MLookupField) field, true, keyLong, keyText);
 			resolveLookup.thenAccept(llv -> sync.asyncExec(() -> {
-				if (llv.isEmpty()) {
-					((Lookup) control).getDescription().setText("");
-					((Lookup) control).setText("");
-					((Lookup) control).setMessage("?");
-				} else {
-					field.setValue(llv.get(0), false);
-					updateControlFromValue(control, llv.get(0));
-					// verlassen dann diese Methode
-				}
+				Value v = llv.isEmpty() ? null : llv.get(0);
+				field.setValue(v, false);
+				updateControlFromValue(control, v);
 			}));
 		}
 	}


### PR DESCRIPTION
Altes Verhalten: 
Bei einem Lookup, dass nicht aufgelöst werden kann, wird ein Fragezeichen als Message eingetragen

<img width="1515" alt="Bildschirmfoto 2021-06-17 um 10 07 19" src="https://user-images.githubusercontent.com/77741125/122357239-d8b66780-cf53-11eb-9fb9-5415329e6110.png">

Neues Verhalten:
Der Value wird auf null gesetzt

<img width="1471" alt="Bildschirmfoto 2021-06-17 um 10 06 54" src="https://user-images.githubusercontent.com/77741125/122357259-dd7b1b80-cf53-11eb-83d6-2b55254ea042.png">

