### PR TITLE
Update of target platform auf 2021-06

### DIFF
--- a/releng/target-definition/eclipse-2021-03.target
+++ b/releng/target-definition/eclipse-2021-03.target
@@ -3,7 +3,7 @@
 <target name="eclipse-2020-12">
 <locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/releases/2021-03"/>
+			<repository location="http://download.eclipse.org/releases/2021-06"/>
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 		</location>


### PR DESCRIPTION
Damit unsere RCP app von den neusten Platform und SWT Fixes profitiert,
sollten wir regelmässig updaten.