### PR TITLE
Angeheftete Perspektiven persistieren

### DIFF
--- a/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
+++ b/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
@@ -94,14 +94,17 @@ public class Constants {
 	 */
 
 	public static final String FORM_NAME = "aero.minova.rcp.perspectiveswitcher.parameters.formName"; //$NON-NLS-1$
-
 	public static final String FORM_ID = "aero.minova.rcp.perspectiveswitcher.parameters.formId"; //$NON-NLS-1$
-
 	public static final String FORM_LABEL = "aero.minova.rcp.perspectiveswitcher.parameters.perspectiveLabel"; //$NON-NLS-1$
-
-	public static final String PERSPECTIVE_TOOLBAR = "perspectivetoolbar";
 	
+	public static final String PERSPECTIVE_TOOLBAR = "perspectivetoolbar";
 	public static final String PREFERENCES_KEPTPERSPECTIVES = "aero.minova.rcp.preferences.keptperspectives";
+	public static final String KEPT_PERSPECTIVE_FORMNAME = ".FormName";
+	public static final String KEPT_PERSPECTIVE_FORMID = ".FormId";
+	public static final String KEPT_PERSPECTIVE_FORMLABEL = ".FormLabel";
+	public static final String KEPT_PERSPECTIVE_ICONURI = ".IconURI";
+	public static final String KEPT_PERSPECTIVE_LOCALIZEDLABEL = ".LocalizedLabel";
+	public static final String KEPT_PERSPECTIVE_LOCALIZEDTOOLTIP = ".LocalizedToolTip";
 
 	/**
 	 * Hier werden Standard-Einstellungen definiert, die wirklich oft genutzt werden

--- a/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
+++ b/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
@@ -99,6 +99,10 @@ public class Constants {
 
 	public static final String FORM_LABEL = "aero.minova.rcp.perspectiveswitcher.parameters.perspectiveLabel"; //$NON-NLS-1$
 
+	public static final String PERSPECTIVE_TOOLBAR = "perspectivetoolbar";
+	
+	public static final String PREFERENCES_KEPTPERSPECTIVES = "aero.minova.rcp.preferences.keptperspectives";
+
 	/**
 	 * Hier werden Standard-Einstellungen definiert, die wirklich oft genutzt werden
 	 *

--- a/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
+++ b/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
@@ -96,9 +96,11 @@ public class Constants {
 	public static final String FORM_NAME = "aero.minova.rcp.perspectiveswitcher.parameters.formName"; //$NON-NLS-1$
 	public static final String FORM_ID = "aero.minova.rcp.perspectiveswitcher.parameters.formId"; //$NON-NLS-1$
 	public static final String FORM_LABEL = "aero.minova.rcp.perspectiveswitcher.parameters.perspectiveLabel"; //$NON-NLS-1$
-	
+
 	public static final String PERSPECTIVE_TOOLBAR = "perspectivetoolbar";
 	public static final String PREFERENCES_KEPTPERSPECTIVES = "aero.minova.rcp.preferences.keptperspectives";
+	public static final String PREFERENCES_TOOLBARORDER = "aero.minova.rcp.preferences.toolbarorder";
+
 	public static final String KEPT_PERSPECTIVE_FORMNAME = ".FormName";
 	public static final String KEPT_PERSPECTIVE_FORMID = ".FormId";
 	public static final String KEPT_PERSPECTIVE_FORMLABEL = ".FormLabel";

--- a/bundles/aero.minova.rcp.perspectiveswitcher/META-INF/MANIFEST.MF
+++ b/bundles/aero.minova.rcp.perspectiveswitcher/META-INF/MANIFEST.MF
@@ -15,7 +15,9 @@ Require-Bundle: org.eclipse.e4.core.contexts,
  org.eclipse.e4.core.services,
  org.eclipse.core.commands,
  org.eclipse.ui.forms,
- aero.minova.rcp.constant;bundle-version="12.0.15"
+ aero.minova.rcp.constant;bundle-version="12.0.15",
+ org.eclipse.equinox.preferences,
+ org.eclipse.e4.core.di.extensions
 Export-Package: aero.minova.rcp.perspectiveswitcher.commands,
  aero.minova.rcp.perspectiveswitcher.handler
 Import-Package: javax.inject;version="1.0.0"

--- a/bundles/aero.minova.rcp.perspectiveswitcher/src/aero/minova/rcp/perspectiveswitcher/handler/KeepPerspectiveHandler.java
+++ b/bundles/aero.minova.rcp.perspectiveswitcher/src/aero/minova/rcp/perspectiveswitcher/handler/KeepPerspectiveHandler.java
@@ -20,18 +20,13 @@ import aero.minova.rcp.constants.Constants;
 import aero.minova.rcp.perspectiveswitcher.commands.E4WorkbenchParameterConstants;
 
 /**
- * Dieser Handler wird im PopupMenu aufgerufen. Toolitems, die mit diesem
- * Handler makiert wurden, werden nach dem schließen der Perspektive nicht aus
- * der Toolbar entfernt. So kann man die Perspektive erneutr aus der Toolbar aus
- * öffnen.
+ * Dieser Handler wird im PopupMenu aufgerufen. Toolitems, die mit diesem Handler makiert wurden, werden nach dem schließen der Perspektive nicht aus der
+ * Toolbar entfernt. So kann man die Perspektive erneutr aus der Toolbar aus öffnen.
  * 
  * @author bauer
- *
  */
 
 public class KeepPerspectiveHandler {
-	
-	
 
 	@Inject
 	MApplication application;
@@ -41,33 +36,36 @@ public class KeepPerspectiveHandler {
 
 	@Inject
 	EPartService partService;
-	
+
 	Preferences prefs = InstanceScope.INSTANCE.getNode(Constants.PREFERENCES_KEPTPERSPECTIVES);
 
 	@Execute
 	public void execute(MWindow window, @Optional @Named(E4WorkbenchParameterConstants.FORM_NAME) String perspectiveId) {
 
-		List<MPerspective> perspectives = modelService.findElements(window, perspectiveId, MPerspective.class);
-		MPerspective perspective = perspectives.get(0);
-
 		String keptPerspective = prefs.get(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMNAME, "");
 
 		if (keptPerspective.isBlank()) {
-			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMNAME, perspective.getPersistedState().get(Constants.FORM_NAME));
-			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMID, perspective.getElementId());
-			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMLABEL, perspective.getLabel());
-			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_ICONURI, perspective.getIconURI());
-			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_LOCALIZEDLABEL, perspective.getLocalizedLabel());
-			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_LOCALIZEDTOOLTIP, perspective.getLocalizedTooltip());
+			List<MPerspective> perspectives = modelService.findElements(window, perspectiveId, MPerspective.class);
+			MPerspective perspective = perspectives.get(0);
+
+			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMID, perspective.getElementId() == null ? "" : perspective.getElementId());
+			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMNAME,
+					perspective.getPersistedState().get(Constants.FORM_NAME) == null ? "" : perspective.getPersistedState().get(Constants.FORM_NAME));
+			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMLABEL, perspective.getLabel() == null ? "" : perspective.getLabel());
+			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_ICONURI, perspective.getIconURI() == null ? "" : perspective.getIconURI());
+			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_LOCALIZEDLABEL,
+					perspective.getLocalizedLabel() == null ? "" : perspective.getLocalizedLabel());
+			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_LOCALIZEDTOOLTIP,
+					perspective.getLocalizedTooltip() == null ? "" : perspective.getLocalizedTooltip());
 		} else {
-			prefs.remove(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMNAME);
 			prefs.remove(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMID);
+			prefs.remove(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMNAME);
 			prefs.remove(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMLABEL);
 			prefs.remove(perspectiveId + Constants.KEPT_PERSPECTIVE_ICONURI);
 			prefs.remove(perspectiveId + Constants.KEPT_PERSPECTIVE_LOCALIZEDLABEL);
 			prefs.remove(perspectiveId + Constants.KEPT_PERSPECTIVE_LOCALIZEDTOOLTIP);
 		}
-		
+
 		try {
 			prefs.flush();
 		} catch (BackingStoreException e1) {

--- a/bundles/aero.minova.rcp.perspectiveswitcher/src/aero/minova/rcp/perspectiveswitcher/handler/KeepPerspectiveHandler.java
+++ b/bundles/aero.minova.rcp.perspectiveswitcher/src/aero/minova/rcp/perspectiveswitcher/handler/KeepPerspectiveHandler.java
@@ -1,18 +1,19 @@
 package aero.minova.rcp.perspectiveswitcher.handler;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
+import org.osgi.service.prefs.BackingStoreException;
+import org.osgi.service.prefs.Preferences;
 
+import aero.minova.rcp.constants.Constants;
 import aero.minova.rcp.perspectiveswitcher.commands.E4WorkbenchParameterConstants;
 
 /**
@@ -26,6 +27,8 @@ import aero.minova.rcp.perspectiveswitcher.commands.E4WorkbenchParameterConstant
  */
 
 public class KeepPerspectiveHandler {
+	
+	
 
 	@Inject
 	MApplication application;
@@ -35,26 +38,27 @@ public class KeepPerspectiveHandler {
 
 	@Inject
 	EPartService partService;
+	
+	Preferences prefs = InstanceScope.INSTANCE.getNode(Constants.PREFERENCES_KEPTPERSPECTIVES);
 
 	@SuppressWarnings("unchecked")
 	@Execute
 	public void execute(MWindow window, @Optional @Named(E4WorkbenchParameterConstants.FORM_NAME) String perspectiveId) {
 
-		List<String> keepItToolitems;
 
-		keepItToolitems = (List<String>) application.getContext().get("perspectivetoolbar");
-		
-		if (keepItToolitems == null) {
-			keepItToolitems = new ArrayList<String>();
-			application.getContext().set("perspectivetoolbar", keepItToolitems);
-		}
+		String keptPerspective = prefs.get(perspectiveId, "");
 
-		if (keepItToolitems.contains(perspectiveId)) {
-			keepItToolitems.remove(perspectiveId);
+		if (keptPerspective.isBlank()) {
+			prefs.put(perspectiveId, perspectiveId);
 		} else {
-			keepItToolitems.add(perspectiveId);
+			prefs.remove(perspectiveId);
 		}
-
+		
+		try {
+			prefs.flush();
+		} catch (BackingStoreException e1) {
+			e1.printStackTrace();
+		}
 	}
 
 }

--- a/bundles/aero.minova.rcp.perspectiveswitcher/src/aero/minova/rcp/perspectiveswitcher/handler/KeepPerspectiveHandler.java
+++ b/bundles/aero.minova.rcp.perspectiveswitcher/src/aero/minova/rcp/perspectiveswitcher/handler/KeepPerspectiveHandler.java
@@ -1,5 +1,7 @@
 package aero.minova.rcp.perspectiveswitcher.handler;
 
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -7,6 +9,7 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.model.application.MApplication;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
@@ -41,17 +44,28 @@ public class KeepPerspectiveHandler {
 	
 	Preferences prefs = InstanceScope.INSTANCE.getNode(Constants.PREFERENCES_KEPTPERSPECTIVES);
 
-	@SuppressWarnings("unchecked")
 	@Execute
 	public void execute(MWindow window, @Optional @Named(E4WorkbenchParameterConstants.FORM_NAME) String perspectiveId) {
 
+		List<MPerspective> perspectives = modelService.findElements(window, perspectiveId, MPerspective.class);
+		MPerspective perspective = perspectives.get(0);
 
-		String keptPerspective = prefs.get(perspectiveId, "");
+		String keptPerspective = prefs.get(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMNAME, "");
 
 		if (keptPerspective.isBlank()) {
-			prefs.put(perspectiveId, perspectiveId);
+			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMNAME, perspective.getPersistedState().get(Constants.FORM_NAME));
+			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMID, perspective.getElementId());
+			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMLABEL, perspective.getLabel());
+			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_ICONURI, perspective.getIconURI());
+			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_LOCALIZEDLABEL, perspective.getLocalizedLabel());
+			prefs.put(perspectiveId + Constants.KEPT_PERSPECTIVE_LOCALIZEDTOOLTIP, perspective.getLocalizedTooltip());
 		} else {
-			prefs.remove(perspectiveId);
+			prefs.remove(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMNAME);
+			prefs.remove(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMID);
+			prefs.remove(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMLABEL);
+			prefs.remove(perspectiveId + Constants.KEPT_PERSPECTIVE_ICONURI);
+			prefs.remove(perspectiveId + Constants.KEPT_PERSPECTIVE_LOCALIZEDLABEL);
+			prefs.remove(perspectiveId + Constants.KEPT_PERSPECTIVE_LOCALIZEDTOOLTIP);
 		}
 		
 		try {

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/ClosePerspectiveHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/ClosePerspectiveHandler.java
@@ -9,7 +9,6 @@ import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
-import org.eclipse.e4.ui.model.application.ui.advanced.MPerspectiveStack;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
@@ -34,15 +33,12 @@ public class ClosePerspectiveHandler extends SwitchPerspectiveHandler {
 	@Execute
 	public void execute(MWindow window, @Optional @Named(E4WorkbenchParameterConstants.FORM_NAME) String perspectiveId) {
 
-		List<MPerspective> perspective = modelService.findElements(application, perspectiveId, MPerspective.class);
-
 		/*
 		 * Entfernt die aktuelle Perspektive.
 		 */
-
-		MPerspectiveStack perspectiveStack = (MPerspectiveStack) modelService.find("aero.minova.rcp.rcp.perspectivestack", application);
-		// perspectiveStack.getChildren().remove(perspective.get(0));
+		List<MPerspective> perspective = modelService.findElements(application, perspectiveId, MPerspective.class);
 		modelService.deleteModelElement(perspective.get(0));
+
 		/*
 		 * Wechselt zur Perspektive, die in der PerspektiveList den Index 0 hat.
 		 */

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/ClosePerspectiveHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/ClosePerspectiveHandler.java
@@ -37,14 +37,17 @@ public class ClosePerspectiveHandler extends SwitchPerspectiveHandler {
 		 * Entfernt die aktuelle Perspektive.
 		 */
 		List<MPerspective> perspective = modelService.findElements(application, perspectiveId, MPerspective.class);
+		boolean activePerspective = perspective.get(0) == modelService.getActivePerspective(window);
 		modelService.deleteModelElement(perspective.get(0));
 
 		/*
-		 * Wechselt zur Perspektive, die in der PerspektiveList den Index 0 hat.
+		 * Wechselt zur Perspektive, die in der PerspektiveList den Index 0 hat, wenn geschlossene Perspektive die aktive war
 		 */
-		List<MPerspective> perspectiveList = modelService.findElements(application, null, MPerspective.class);
-		if (!perspectiveList.isEmpty()) {
-			switchTo(perspectiveList.get(0), perspectiveList.get(0).getElementId(), window);
+		if (activePerspective) {
+			List<MPerspective> perspectiveList = modelService.findElements(application, null, MPerspective.class);
+			if (!perspectiveList.isEmpty()) {
+				switchTo(perspectiveList.get(0), perspectiveList.get(0).getElementId(), window);
+			}
 		}
 	}
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
@@ -127,7 +127,13 @@ public class PerspectiveControl {
 		List<MPerspective> perspectives = modelService.findElements(window, null, MPerspective.class);
 		for (MPerspective perspective : perspectives) {
 			if (perspective.isToBeRendered()) {
-				addPerspectiveShortcut(perspective.getElementId(), true);
+				addPerspectiveShortcut(perspective.getElementId(), //
+						perspective.getPersistedState().get(Constants.FORM_NAME), //
+						perspective.getLabel(), //
+						perspective.getIconURI(), //
+						perspective.getLocalizedLabel(), //
+						perspective.getLocalizedTooltip(), //
+						true);
 				ids.add(perspective.getElementId());
 			}
 			if (perspective == modelService.getActivePerspective(window)) {
@@ -139,7 +145,13 @@ public class PerspectiveControl {
 			for (String key : prefs.keys()) {
 				String id = key.substring(0, key.indexOf("."));
 				if (!ids.contains(id)) {
-					addPerspectiveShortcut(id, true);
+					addPerspectiveShortcut(id, //
+							prefs.get(id + Constants.KEPT_PERSPECTIVE_FORMNAME, ""), //
+							prefs.get(id + Constants.KEPT_PERSPECTIVE_FORMLABEL, ""), //
+							prefs.get(id + Constants.KEPT_PERSPECTIVE_ICONURI, ""), //
+							prefs.get(id + Constants.KEPT_PERSPECTIVE_LOCALIZEDLABEL, ""), //
+							prefs.get(id + Constants.KEPT_PERSPECTIVE_LOCALIZEDTOOLTIP, ""), //
+							true);
 					ids.add(id);
 				}
 			}
@@ -166,9 +178,7 @@ public class PerspectiveControl {
 
 	private void translate() {
 		for (ToolItem item : toolBar.getItems()) {
-			List<MPerspective> perspectives = modelService.findElements(application, item.getData().toString(), MPerspective.class);
-			MPerspective perspective = perspectives.get(0);
-			String value = translationService.translate(perspective.getLocalizedLabel(), null);
+			String value = translationService.translate(item.getText(), null);
 			item.setText(value);
 		}
 		toolBar.pack(true);
@@ -188,13 +198,14 @@ public class PerspectiveControl {
 	/*
 	 * Add shortcut for the perspective in the toolbar
 	 */
-	public void addPerspectiveShortcut(String perspectiveId, boolean openAll) {
+	public void addPerspectiveShortcut(String perspectiveId, String formName, String formLable, String iconURI, String localizedLabel, String localizedTooltip,
+			boolean openAll) {
 		String keptPerspective = prefs.get(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMNAME, "");
 
 		if (keptPerspective.isBlank() || openAll) {
 			shortcut = new ToolItem(toolBar, SWT.RADIO);
 			shortcut.setData(perspectiveId);
-			ImageDescriptor descriptor = getIconFor(prefs.get(perspectiveId + Constants.KEPT_PERSPECTIVE_ICONURI, ""));
+			ImageDescriptor descriptor = getIconFor(iconURI);
 
 			if (descriptor != null) {
 				Image icon = descriptor.createImage();
@@ -203,20 +214,18 @@ public class PerspectiveControl {
 
 			if (descriptor == null) {
 				// Kein Icon, oder explizit gewünscht, Label wird als Text übernommen
-				shortcut.setText(prefs.get(perspectiveId + Constants.KEPT_PERSPECTIVE_LOCALIZEDLABEL, "") != null
-						? prefs.get(perspectiveId + Constants.KEPT_PERSPECTIVE_LOCALIZEDLABEL, "")
-						: "");
+				shortcut.setText(localizedLabel != null ? localizedLabel : "");
 			}
-			shortcut.setToolTipText(prefs.get(perspectiveId + Constants.KEPT_PERSPECTIVE_LOCALIZEDTOOLTIP, ""));
+			shortcut.setToolTipText(localizedTooltip);
 
 			shortcut.addSelectionListener(new SelectionAdapter() {
 
 				@Override
 				public void widgetSelected(SelectionEvent event) {
 					Map<String, String> parameter = Map.of(//
-							Constants.FORM_NAME, prefs.get(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMNAME, ""), //
+							Constants.FORM_NAME, formName, //
 							Constants.FORM_ID, perspectiveId, //
-							Constants.FORM_LABEL, prefs.get(perspectiveId + Constants.KEPT_PERSPECTIVE_FORMLABEL, ""));
+							Constants.FORM_LABEL, formLable);
 
 					ParameterizedCommand command = commandService.createCommand("aero.minova.rcp.rcp.command.openform", parameter);
 					handlerService.executeHandler(command);
@@ -304,7 +313,7 @@ public class PerspectiveControl {
 	}
 
 	public void removePerspectiveShortcut(MPerspective perspective) {
-		String keptPerspective = prefs.get(perspective.getElementId(), "");
+		String keptPerspective = prefs.get(perspective.getElementId() + Constants.KEPT_PERSPECTIVE_FORMNAME, "");
 
 		if (keptPerspective.isBlank()) {
 			ToolItem item = getToolItemFor(perspective.getElementId());
@@ -438,7 +447,13 @@ public class PerspectiveControl {
 					continue;
 				}
 
-				this.addPerspectiveShortcut(added.getElementId(), false);
+				this.addPerspectiveShortcut(added.getElementId(), //
+						added.getPersistedState().get(Constants.FORM_NAME), //
+						added.getLabel(), //
+						added.getIconURI(), //
+						added.getLocalizedLabel(), //
+						added.getLocalizedTooltip(), //
+						false);
 			}
 		} else if (UIEvents.isREMOVE(event)) {
 			for (Object o : UIEvents.asIterable(event, UIEvents.EventTags.OLD_VALUE)) {

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
@@ -123,7 +123,7 @@ public class PerspectiveControl {
 		List<MPerspective> perspectives = modelService.findElements(window, null, MPerspective.class);
 		for (MPerspective perspective : perspectives) {
 			if (perspective.isToBeRendered()) {
-				addPerspectiveShortcut(perspective);
+				addPerspectiveShortcut(perspective, true);
 			}
 			if (perspective == modelService.getActivePerspective(window)) {
 				setSelectedElement(perspective);
@@ -170,10 +170,10 @@ public class PerspectiveControl {
 	/*
 	 * Add shortcut for the perspective in the toolbar
 	 */
-	public void addPerspectiveShortcut(MPerspective perspective) {
+	public void addPerspectiveShortcut(MPerspective perspective, boolean openAll) {
 		String keptPerspective = prefs.get(perspective.getElementId(), "");
 
-		if (keptPerspective.isBlank()) {
+		if (keptPerspective.isBlank() || openAll) {
 			shortcut = new ToolItem(toolBar, SWT.RADIO);
 			shortcut.setData(perspective.getElementId());
 			ImageDescriptor descriptor = getIconFor(perspective.getIconURI());
@@ -341,7 +341,7 @@ public class PerspectiveControl {
 				handlerService.executeHandler(command);
 
 				String newKeptPerspective = prefs.get(perspectiveId, "");
-				
+
 				// Entfernt das Toolitem wenn die Perspektive geschlossen ist und das KeepIt
 				// Kennzeichen gelöscht wird.
 				if (newKeptPerspective.isBlank() && perspective == null) {
@@ -420,7 +420,7 @@ public class PerspectiveControl {
 					continue;
 				}
 
-				this.addPerspectiveShortcut(added);
+				this.addPerspectiveShortcut(added, false);
 			}
 		} else if (UIEvents.isREMOVE(event)) {
 			for (Object o : UIEvents.asIterable(event, UIEvents.EventTags.OLD_VALUE)) {

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
@@ -327,7 +327,6 @@ public class PerspectiveControl {
 		});
 	}
 
-	@SuppressWarnings("unchecked")
 	private void addKeepItMenuItem(Menu menu, String perspectiveId, MPerspective perspective) {
 		final MenuItem menuItem = new MenuItem(menu, SWT.CHECK);
 		String keptPerspective = prefs.get(perspectiveId, "");
@@ -343,7 +342,7 @@ public class PerspectiveControl {
 				String newKeptPerspective = prefs.get(perspectiveId, "");
 
 				// Entfernt das Toolitem wenn die Perspektive geschlossen ist und das KeepIt Kennzeichen gelöscht wird.
-				if (keptPerspective.isBlank() && perspective == null) {
+				if (newKeptPerspective.isBlank() && perspective == null) {
 					ToolItem toolitem = getToolItemFor(perspectiveId);
 					removeToolItem(toolitem);
 				}

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
@@ -330,7 +330,7 @@ public class PerspectiveControl {
 	@SuppressWarnings("unchecked")
 	private void addKeepItMenuItem(Menu menu, String perspectiveId, MPerspective perspective) {
 		final MenuItem menuItem = new MenuItem(menu, SWT.CHECK);
-		String keptPerspective = prefs.get(perspective.getElementId(), "");
+		String keptPerspective = prefs.get(perspectiveId, "");
 
 		menuItem.setText(translationService.translate("@Action.KeepIt", null));
 		menuItem.addSelectionListener(new SelectionAdapter() {
@@ -342,9 +342,8 @@ public class PerspectiveControl {
 
 				String newKeptPerspective = prefs.get(perspectiveId, "");
 
-				// Entfernt das Toolitem wenn die Perspektive geschlossen ist und das KeepIt
-				// Kennzeichen gelöscht wird.
-				if (newKeptPerspective.isBlank() && perspective == null) {
+				// Entfernt das Toolitem wenn die Perspektive geschlossen ist und das KeepIt Kennzeichen gelöscht wird.
+				if (keptPerspective.isBlank() && perspective == null) {
 					ToolItem toolitem = getToolItemFor(perspectiveId);
 					removeToolItem(toolitem);
 				}

--- a/bundles/aero.minova.rcp.workspace/ModelVersion.txt
+++ b/bundles/aero.minova.rcp.workspace/ModelVersion.txt
@@ -1,5 +1,10 @@
 Version 2.1
 
+## Version 2.2   ##
+## 05.07.2021    ##
+## 12.0.23       ##
+Angeheftete Toolbaritems persistieren und in korrekter Reihenfolge öffnen
+
 ## Version 2.1   ##
 ## 18.06.2021    ##
 ## 12.0.21       ##


### PR DESCRIPTION
Angeheftete Perspektiven sind nach einem Neustart wieder angeheftet.
Außerdem werden die Perspektiven in der Toolbar in der gleichen Reihenfolge wie vor dem Neustart angezeigt.

closes #597