### PR TITLE
Formatierung des Datums und der Zeit

### DIFF
--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/DateTimeValueAccessor.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/DateTimeValueAccessor.java
@@ -8,11 +8,16 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.nebula.widgets.opal.textassist.TextAssist;
 import org.eclipse.swt.widgets.Control;
+import org.osgi.service.prefs.Preferences;
 
 import aero.minova.rcp.model.Value;
 import aero.minova.rcp.model.form.MField;
+import aero.minova.rcp.preferences.ApplicationPreferences;
+import aero.minova.rcp.preferencewindow.builder.DisplayType;
+import aero.minova.rcp.preferencewindow.builder.InstancePreferenceAccessor;
 
 public class DateTimeValueAccessor extends AbstractValueAccessor {
 
@@ -22,14 +27,25 @@ public class DateTimeValueAccessor extends AbstractValueAccessor {
 
 	@Override
 	protected void updateControlFromValue(Control control, Value value) {
+		Locale locale = (Locale) control.getData(TRANSLATE_LOCALE);
+		Preferences preferences = InstanceScope.INSTANCE.getNode(ApplicationPreferences.PREFERENCES_NODE);
+		String dateUtil = (String) InstancePreferenceAccessor.getValue(preferences, ApplicationPreferences.DATE_UTIL, DisplayType.DATE_UTIL, "", locale);
+		String timeUtil = (String) InstancePreferenceAccessor.getValue(preferences, ApplicationPreferences.TIME_UTIL, DisplayType.TIME_UTIL, "", locale);
+
+		
 		if (value == null) {
 			((TextAssist) control).setText("");
 		} else {
 			Instant date = value.getInstantValue();
 			LocalDateTime localDateTime = LocalDateTime.ofInstant(date, ZoneId.of("UTC"));
-			Locale locale = (Locale) control.getData(TRANSLATE_LOCALE);
-			// Bei der Formatierung geschehen fehler, wir erhalten das Milienium zurück
-			((TextAssist) control).setText(localDateTime.format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm").withLocale(locale)));
+			String pattern = dateUtil + " " + timeUtil;
+			DateTimeFormatter dtf = DateTimeFormatter.ofPattern(pattern);
+			if(dateUtil.isBlank() || timeUtil.isBlank()) {
+				// Bei der Formatierung geschehen fehler, wir erhalten das Milienium zurück
+				((TextAssist) control).setText(localDateTime.format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm").withLocale(locale)));
+			} else {
+				((TextAssist) control).setText(localDateTime.format(dtf));
+			}
 		}
 	}
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/DateTimeValueAccessor.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/DateTimeValueAccessor.java
@@ -32,7 +32,6 @@ public class DateTimeValueAccessor extends AbstractValueAccessor {
 		String dateUtil = (String) InstancePreferenceAccessor.getValue(preferences, ApplicationPreferences.DATE_UTIL, DisplayType.DATE_UTIL, "", locale);
 		String timeUtil = (String) InstancePreferenceAccessor.getValue(preferences, ApplicationPreferences.TIME_UTIL, DisplayType.TIME_UTIL, "", locale);
 
-		
 		if (value == null) {
 			((TextAssist) control).setText("");
 		} else {
@@ -40,9 +39,15 @@ public class DateTimeValueAccessor extends AbstractValueAccessor {
 			LocalDateTime localDateTime = LocalDateTime.ofInstant(date, ZoneId.of("UTC"));
 			String pattern = dateUtil + " " + timeUtil;
 			DateTimeFormatter dtf = DateTimeFormatter.ofPattern(pattern);
-			if(dateUtil.isBlank() || timeUtil.isBlank()) {
+			if (dateUtil.isBlank() && timeUtil.isBlank()) {
 				// Bei der Formatierung geschehen fehler, wir erhalten das Milienium zurück
 				((TextAssist) control).setText(localDateTime.format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm").withLocale(locale)));
+			} else if (timeUtil.isBlank()) {
+				((TextAssist) control).setText(localDateTime.format(DateTimeFormatter.ofPattern(pattern + "HH:mm").withLocale(locale)));
+			} else if (dateUtil.isBlank()) {
+				((TextAssist) control).setText(localDateTime.format(DateTimeFormatter.ofPattern("dd.MM.yyyy" + pattern).withLocale(locale)));
+				String test = ((TextAssist) control).getText();
+				System.out.println(test);
 			} else {
 				((TextAssist) control).setText(localDateTime.format(dtf));
 			}

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/ShortDateValueAccessor.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/ShortDateValueAccessor.java
@@ -9,11 +9,16 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.Locale;
 
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.nebula.widgets.opal.textassist.TextAssist;
 import org.eclipse.swt.widgets.Control;
+import org.osgi.service.prefs.Preferences;
 
 import aero.minova.rcp.model.Value;
 import aero.minova.rcp.model.form.MField;
+import aero.minova.rcp.preferences.ApplicationPreferences;
+import aero.minova.rcp.preferencewindow.builder.DisplayType;
+import aero.minova.rcp.preferencewindow.builder.InstancePreferenceAccessor;
 
 public class ShortDateValueAccessor extends AbstractValueAccessor {
 
@@ -23,14 +28,23 @@ public class ShortDateValueAccessor extends AbstractValueAccessor {
 
 	@Override
 	protected void updateControlFromValue(Control control, Value value) {
+		Locale locale = (Locale) control.getData(TRANSLATE_LOCALE);
+		Preferences preferences = InstanceScope.INSTANCE.getNode(ApplicationPreferences.PREFERENCES_NODE);
+		String dateUtil = (String) InstancePreferenceAccessor.getValue(preferences, ApplicationPreferences.DATE_UTIL, DisplayType.DATE_UTIL, "", locale);
+
 		if (value == null) {
 			((TextAssist) control).setText("");
 		} else {
 			Instant date = value.getInstantValue();
 			LocalDate localDate = LocalDate.ofInstant(date, ZoneId.of("UTC"));
-			Locale locale = (Locale) control.getData(TRANSLATE_LOCALE);
-			// Bei der Formatierung geschehen fehler, wir erhalten das Milienium zurück
-			((TextAssist) control).setText(localDate.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale)));
+			DateTimeFormatter dtf = DateTimeFormatter.ofPattern(dateUtil, locale);
+			if (dateUtil.equals("")) {
+				// Bei der Formatierung geschehen fehler, wir erhalten das Milienium zurück
+				((TextAssist) control).setText(localDate.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale)));
+			} else {
+				// Bei der Formatierung geschehen fehler, wir erhalten das Milienium zurück
+				((TextAssist) control).setText(localDate.format(dtf));
+			}
 		}
 	}
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/ShortTimeValueAccessor.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/ShortTimeValueAccessor.java
@@ -9,11 +9,16 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.Locale;
 
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.nebula.widgets.opal.textassist.TextAssist;
 import org.eclipse.swt.widgets.Control;
+import org.osgi.service.prefs.Preferences;
 
 import aero.minova.rcp.model.Value;
 import aero.minova.rcp.model.form.MField;
+import aero.minova.rcp.preferences.ApplicationPreferences;
+import aero.minova.rcp.preferencewindow.builder.DisplayType;
+import aero.minova.rcp.preferencewindow.builder.InstancePreferenceAccessor;
 
 public class ShortTimeValueAccessor extends AbstractValueAccessor {
 
@@ -23,13 +28,21 @@ public class ShortTimeValueAccessor extends AbstractValueAccessor {
 
 	@Override
 	protected void updateControlFromValue(Control control, Value value) {
+		Locale locale = (Locale) control.getData(TRANSLATE_LOCALE);
+		Preferences preferences = InstanceScope.INSTANCE.getNode(ApplicationPreferences.PREFERENCES_NODE);
+		String timeUtil = (String) InstancePreferenceAccessor.getValue(preferences, ApplicationPreferences.TIME_UTIL, DisplayType.TIME_UTIL, "", locale);
+
 		if (value == null) {
 			((TextAssist) control).setText("");
 		} else {
 			Instant time = value.getInstantValue();
 			LocalTime localTime = LocalTime.ofInstant(time, ZoneId.of("UTC"));
-			Locale locale = (Locale) control.getData(TRANSLATE_LOCALE);
-			((TextAssist) control).setText(localTime.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(locale)));
+			DateTimeFormatter dtf = DateTimeFormatter.ofPattern(timeUtil, locale);
+			if(timeUtil.equals("")) {
+				((TextAssist) control).setText(localTime.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(locale)));
+			} else {
+				((TextAssist) control).setText(localTime.format(dtf));
+			}
 		}
 	}
 }

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/DateTimeField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/DateTimeField.java
@@ -70,10 +70,18 @@ public class DateTimeField {
 							locale);
 					LocalDateTime localeDateTime = LocalDateTime.ofInstant(date, ZoneId.of("UTC"));
 					String pattern = dateUtil + " " + timeUtil;
-					DateTimeFormatter dtf = DateTimeFormatter.ofPattern(pattern);
-					if (dateUtil.isBlank() || timeUtil.isBlank()) {
+					if (dateUtil.isBlank() && timeUtil.isBlank()) {
 						result.add(DateTimeUtil.getDateTimeString(date, locale));
+					} else if (dateUtil.isBlank()) {
+						String datePattern = "dd.MM.yyyy" + pattern;
+						DateTimeFormatter dtf = DateTimeFormatter.ofPattern(datePattern);
+						result.add(localeDateTime.format(dtf));
+					} else if (timeUtil.isBlank()) {
+						String timePattern = pattern + "HH:mm";
+						DateTimeFormatter dtf = DateTimeFormatter.ofPattern(timePattern);
+						result.add(localeDateTime.format(dtf));
 					} else {
+						DateTimeFormatter dtf = DateTimeFormatter.ofPattern(pattern);
 						result.add(localeDateTime.format(dtf));
 					}
 					field.setValue(new Value(date), true);


### PR DESCRIPTION
Dieser PullRequest ergänzt die Formatierung des Datums und der Zeit. Dabei wird nun, wenn nichts in den Preferences angegeben ist, die von uns bestimmte Formatierung genutzt. 

Für das Datum gilt: FormatStyle.MEDIUM
Für die Zeit gilt: FormatStyle.SHORT