### PR TITLE
Fixes GridTest

### DIFF
--- a/tests/aero.minova.rcp.uitests/META-INF/MANIFEST.MF
+++ b/tests/aero.minova.rcp.uitests/META-INF/MANIFEST.MF
@@ -10,7 +10,6 @@ Require-Bundle: org.eclipse.swtbot.e4.finder;bundle-version="3.1.0",
  org.eclipse.jface;bundle-version="3.22.200",
  org.eclipse.swtbot.eclipse.finder;bundle-version="3.1.0",
  org.apache.log4j;bundle-version="1.2.15",
- org.junit;bundle-version="4.13.0",
  org.eclipse.swtbot.junit4_x;bundle-version="3.1.0",
  org.eclipse.e4.ui.model.workbench;bundle-version="2.1.1000",
  org.eclipse.swtbot.nebula.nattable.finder;bundle-version="3.1.0",
@@ -34,11 +33,13 @@ Require-Bundle: org.eclipse.swtbot.e4.finder;bundle-version="3.1.0",
  aero.minova.workingtime.helper;bundle-version="12.0.21",
  org.eclipse.e4.core.contexts;bundle-version="1.8.400",
  org.eclipse.e4.core.commands,
- org.eclipse.e4.core.services
+ org.eclipse.e4.core.services,
+ org.eclipse.swtbot.junit5_x;bundle-version="3.1.0",
+ org.junit.jupiter.api;bundle-version="5.7.1"
 Import-Package: org.eclipse.e4.core.contexts,
  org.eclipse.e4.ui.workbench,
  org.eclipse.e4.ui.workbench.modeling,
  org.eclipse.ui.forms.widgets,
- org.junit.jupiter.api;version="5.7.1",
+ org.opentest4j;version="1.2.0",
  org.osgi.framework;version="1.10.0"
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
indexNattable.rowCount() gibt nur die Anzahl der sichtbaren Testeinträge
zurück. Sobald mehr als sichtbare Einträge in der Tabelle verfügbar
waren, schlugen die Tests fehlt, in der BeforeEach Methode wird die
Anzahl der Einträge in der Tabelle jetzt auf 8 limitiert, eine
Alternative Implementierung könnte auch in der NatTable nach unten
scrollen, aber ich vermute, dass wir die Anzahl der Testeinträge relativ
klein halten wollen.

Desweiteren generelle Aufräumarbeiten.