### PR TITLE
Entferne LookupControl von css

### DIFF
--- a/bundles/aero.minova.rcp.css/css/L/size_14.css
+++ b/bundles/aero.minova.rcp.css/css/L/size_14.css
@@ -3,7 +3,7 @@
 @import url("platform:/plugin/aero.minova.rcp.css/css/common.css");
 @import url("platform:/plugin/aero.minova.rcp.css/css/common/nattable.css");
 
-Widget, CTabItem, LookupControl, ToolBar, ToolTip, Label, Button, LookupTwistie {
+Widget, CTabItem, ToolBar, ToolTip, Label, Button, LookupTwistie {
 	font-size: 14px;
 }
 	

--- a/bundles/aero.minova.rcp.css/css/M/size_10.css
+++ b/bundles/aero.minova.rcp.css/css/M/size_10.css
@@ -3,7 +3,7 @@
 @import url("platform:/plugin/aero.minova.rcp.css/css/common.css");
 @import url("platform:/plugin/aero.minova.rcp.css/css/common/nattable.css");
 
-Widget, CTabItem, LookupControl, ToolBar, ToolTip, Label, Button, LookupTwistie {
+Widget, CTabItem, ToolBar, ToolTip, Label, Button, LookupTwistie {
 	/*font-size: 10px;*/
 }
 

--- a/bundles/aero.minova.rcp.css/css/S/size_8.css
+++ b/bundles/aero.minova.rcp.css/css/S/size_8.css
@@ -3,7 +3,7 @@
 @import url("platform:/plugin/aero.minova.rcp.css/css/common.css");
 @import url("platform:/plugin/aero.minova.rcp.css/css/common/nattable.css");
 
-Widget, CTabItem, LookupControl, ToolBar, ToolTip, Label, Button, LookupTwistie {
+Widget, CTabItem, ToolBar, ToolTip, Label, Button, LookupTwistie {
 	font-size: 8px;
 }
 

--- a/bundles/aero.minova.rcp.css/css/XL/size_20.css
+++ b/bundles/aero.minova.rcp.css/css/XL/size_20.css
@@ -3,7 +3,7 @@
 @import url("platform:/plugin/aero.minova.rcp.css/css/common.css");
 @import url("platform:/plugin/aero.minova.rcp.css/css/common/nattable.css");
 
-Widget, CTabItem, LookupControl, ToolBar, ToolTip, Label, Button, LookupTwistie {
+Widget, CTabItem, ToolBar, ToolTip, Label, Button, LookupTwistie {
 	font-size: 20px;
 }
 

--- a/bundles/aero.minova.rcp.css/css/colors.css
+++ b/bundles/aero.minova.rcp.css/css/colors.css
@@ -1,6 +1,5 @@
 CTabItem, LayoutComposite, ExpandableComposite,
-	ScrolledComposite, Canvas, DetailComposite, ToolBar,
-	LookupControl, NatTable, Section  {
+	ScrolledComposite, Canvas, DetailComposite, ToolBar, NatTable, Section  {
 	background-color: COLOR-WIDGET-BACKGROUND;
 }
 Label, Button, Section  {
@@ -62,9 +61,7 @@ Text#Console {
 	color: white;
 	background-color: black;
 }
-LookupControl Label {
-	color: black;
-}
+
 /*
 
 Label.UnitText {


### PR DESCRIPTION
LookupControl gibt es gar nicht mehr von daher brauchen wir es nicht zu
stylen