### PR TITLE
Text deutlicher hervorheben

### DIFF
--- a/bundles/aero.minova.rcp.css/css/colors.css
+++ b/bundles/aero.minova.rcp.css/css/colors.css
@@ -9,9 +9,10 @@ Label, Section  {
 }
 
 
+/* Für Winows wäre es gut, die Farbe der Buttons auf weiß setzten zu können #768*/
 Button {
 	color: #222222;
-	background-color: white;
+	background-color: inherit;
 }
 
 Label.DescriptionLabel {

--- a/bundles/aero.minova.rcp.css/css/colors.css
+++ b/bundles/aero.minova.rcp.css/css/colors.css
@@ -1,27 +1,23 @@
 CTabItem, LayoutComposite, ExpandableComposite,
 	ScrolledComposite, Canvas, DetailComposite, ToolBar, NatTable, Section  {
 	background-color: COLOR-WIDGET-BACKGROUND;
+	color: #222222;
 }
-Label, Button, Section  {
-	color: #666666;
+Label, Section  {
+	color: #222222;
 	background-color: inherit;
-	/*
-	background-color: #eeee88;
-	*/
 }
-/*
-Composite.TEST {
-	background-color: #ee8888;
+
+
+Button {
+	color: #222222;
+	background-color: white;
 }
-*/
+
 Label.DescriptionLabel {
 	color: black;
 }
-/* 
-Composite, Label {
-	background-color: #e8e8e8;
-}
-*/
+
 
 Composite {
 	background-color: COLOR-WIDGET-BACKGROUND;


### PR DESCRIPTION
Text wird dunkler, damit er auf dem grauen Hintergrund besser lesbar ist.

Vorher:
<img width="1567" alt="Bildschirmfoto 2021-08-30 um 14 28 18" src="https://user-images.githubusercontent.com/77741125/131338900-9f4710dc-01fc-48e3-bb9c-54122977adc9.png">

Nachher:
<img width="1567" alt="Bildschirmfoto 2021-08-30 um 14 27 47" src="https://user-images.githubusercontent.com/77741125/131338878-3a1f01d8-c1d3-4f17-88d5-eb2fd7a64469.png">
