### PR TITLE
Keyzuordnung aus xbs anpassen

### DIFF
--- a/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
+++ b/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
@@ -120,6 +120,7 @@ public class Constants {
 
 	public static final String DETAIL_WIDTH = "Detail_Width";
 	public static final String OPTION_PAGES = "OptionPages";
+	public static final Object OPTION_PAGE_GRID = "OptionPageGrid";
 
 	// Commands
 	public static final String AERO_MINOVA_RCP_RCP_COMMAND_GRIDBUTTONCOMMAND = "aero.minova.rcp.rcp.command.gridbuttoncommand";

--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
@@ -440,7 +440,7 @@ public class DataService implements IDataService {
 	public CompletableFuture<String> getHashedFile(String filename) {
 		logCache("Requested file: " + filename);
 		try {
-			if (checkIfUpdateIsRequired(filename) && false) {
+			if (checkIfUpdateIsRequired(filename)) {
 				logCache(filename + " need to download / update the file ");
 				// File löschen, damit es komplett aktualisiert wird
 				getStoragePath().resolve(filename).toFile().delete();

--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
@@ -440,7 +440,7 @@ public class DataService implements IDataService {
 	public CompletableFuture<String> getHashedFile(String filename) {
 		logCache("Requested file: " + filename);
 		try {
-			if (checkIfUpdateIsRequired(filename)) {
+			if (checkIfUpdateIsRequired(filename) && false) {
 				logCache(filename + " need to download / update the file ");
 				// File löschen, damit es komplett aktualisiert wird
 				getStoragePath().resolve(filename).toFile().delete();

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MDetail.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MDetail.java
@@ -29,7 +29,7 @@ public class MDetail {
 	private Control selectedField;
 
 	private Map<String, Form> optionPages = new HashMap<>();
-	private Map<String, Map<String, Integer>> optionPageKeys = new HashMap<>();
+	private Map<String, Map<String, String>> optionPageKeys = new HashMap<>();
 
 	/**
 	 * Ein neues Feld dem Detail hinzufügen. Dabei muss selbst auf die Eindeutigkeit geachtet werden. Z.B.
@@ -122,11 +122,11 @@ public class MDetail {
 		return optionPages.get(name);
 	}
 
-	public void addOptionPageKeys(String name, Map<String, Integer> keysToIndex) {
-		this.optionPageKeys.put(name, keysToIndex);
+	public void addOptionPageKeys(String name, Map<String, String> keysToValue) {
+		this.optionPageKeys.put(name, keysToValue);
 	}
 
-	public Map<String, Integer> getOptionPageKeys(String name) {
+	public Map<String, String> getOptionPageKeys(String name) {
 		return optionPageKeys.get(name);
 	}
 

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MDetail.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/MDetail.java
@@ -83,7 +83,6 @@ public class MDetail {
 	}
 
 	/**
-	 * ACHTUNG: Felder aus OPs haben aktuell noch kein Präfix! <br>
 	 * Liefert das Feld mit dem Namen. Felder im Detail haben kein Präfix. Felder in einer OptionPage haben das Präfix aus der XBS. z.B.
 	 * <ul>
 	 * <li>"KeyLong" = Das Feld KeyLong der Detail-Maske</li>
@@ -115,7 +114,7 @@ public class MDetail {
 	}
 
 	public void addOptionPage(Form op) {
-		this.optionPages.put(op.getTitle(), op);
+		this.optionPages.put(op.getDetail().getProcedureSuffix(), op);
 	}
 
 	public Form getOptionPage(String name) {

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCDetailPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCDetailPart.java
@@ -325,7 +325,7 @@ public class WFCDetailPart extends WFCFormPart implements ValueChangeListener, G
 
 	private void addOPFromForm(Form opForm, Composite parent, Node opNode) {
 		mDetail.addOptionPage(opForm);
-		mDetail.addOptionPageKeys(opForm.getTitle(), XBSUtil.getKeynamesToIndex(opNode));
+		mDetail.addOptionPageKeys(opForm.getTitle(), XBSUtil.getKeynamesToValues(opNode));
 		for (Object headOrPage : opForm.getDetail().getHeadAndPageAndGrid()) {
 			HeadOrPageOrGridWrapper wrapper = new HeadOrPageOrGridWrapper(headOrPage, true, opForm.getTitle());
 			layoutSection(parent, wrapper);
@@ -339,7 +339,7 @@ public class WFCDetailPart extends WFCFormPart implements ValueChangeListener, G
 		// OP-Feldname zu Index Map aus .xbs setzten
 		MGrid opMGrid = mDetail.getGrid(opGrid.getProcedureSuffix());
 		SectionGrid sg = ((GridAccessor) opMGrid.getGridAccessor()).getSectionGrid();
-		sg.setKeysToIndex(XBSUtil.getKeynamesToIndex(opNode));
+		sg.setKeysToIndex(XBSUtil.getKeynamesToValues(opNode));
 	}
 
 	/**

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCDetailPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCDetailPart.java
@@ -324,22 +324,24 @@ public class WFCDetailPart extends WFCFormPart implements ValueChangeListener, G
 	}
 
 	private void addOPFromForm(Form opForm, Composite parent, Node opNode) {
+		// TODO: Gibt es die Keys -> Fehlermeldung
 		mDetail.addOptionPage(opForm);
-		mDetail.addOptionPageKeys(opForm.getTitle(), XBSUtil.getKeynamesToValues(opNode));
+		mDetail.addOptionPageKeys(opForm.getDetail().getProcedureSuffix(), XBSUtil.getKeynamesToValues(opNode));
 		for (Object headOrPage : opForm.getDetail().getHeadAndPageAndGrid()) {
-			HeadOrPageOrGridWrapper wrapper = new HeadOrPageOrGridWrapper(headOrPage, true, opForm.getTitle());
+			HeadOrPageOrGridWrapper wrapper = new HeadOrPageOrGridWrapper(headOrPage, true, opForm.getDetail().getProcedureSuffix());
 			layoutSection(parent, wrapper);
 		}
 	}
 
 	private void addOPFromGrid(Grid opGrid, Composite parent, Node opNode) {
+		// TODO: Gibt es die Keys -> Fehlermeldung
 		HeadOrPageOrGridWrapper wrapper = new HeadOrPageOrGridWrapper(opGrid);
 		layoutSection(parent, wrapper);
 
 		// OP-Feldname zu Index Map aus .xbs setzten
 		MGrid opMGrid = mDetail.getGrid(opGrid.getProcedureSuffix());
 		SectionGrid sg = ((GridAccessor) opMGrid.getGridAccessor()).getSectionGrid();
-		sg.setKeysToIndex(XBSUtil.getKeynamesToValues(opNode));
+		sg.setFieldnameToValue(XBSUtil.getKeynamesToValues(opNode));
 	}
 
 	/**
@@ -639,6 +641,9 @@ public class WFCDetailPart extends WFCFormPart implements ValueChangeListener, G
 			Field field = (Field) fieldOrGrid;
 			MField f = ModelToViewModel.convert(field);
 			f.addValueChangeListener(this);
+			String fieldName = (headOrPage.isOP ? headOrPage.formTitle + "." : "") + f.getName();
+			f.setName(fieldName);
+
 			getDetail().putField(f);
 
 			if (!field.isVisible()) {

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/processor/MenuProcessor.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/processor/MenuProcessor.java
@@ -60,7 +60,6 @@ public class MenuProcessor {
 			handleNoMDI(dataService);
 		}
 
-		// TODO: Verschieben?
 		try {
 			CompletableFuture<String> xbsFuture = dataService.getHashedFile(XBS_FILE_NAME);
 			String xbsContent = xbsFuture.get();

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/XBSUtil.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/XBSUtil.java
@@ -45,20 +45,19 @@ public class XBSUtil {
 	}
 
 	/**
-	 * Liefert eine Map von Feldnamen in der OP zu "Index" des primary Keys in der Hauptmaske. "Index" 0 bedeutet erstes primary-Feld, es können nicht-primary
-	 * Felder davorstehen.
+	 * Liefert eine Map von Feldnamen in der OP zu Feldnamen in der Hauptmaske <br>
+	 * TODO: Statt Feldnamen in der Hauptmaske können auch direkt Werte enthalten sein (mit @, siehe #825)<br>
+	 * TODO: "visible"-Ausnahme entfernen, sobald das über Helper funktioniert
 	 */
-	public static Map<String, Integer> getKeynamesToIndex(Node node) {
-		Map<String, Integer> namesToIndex = new HashMap<>();
+	public static Map<String, String> getKeynamesToValues(Node node) {
+		Map<String, String> namesToValues = new HashMap<>();
 
 		for (Entry entry : node.getMap().getEntry()) {
-			String uppercaseString = entry.getKey().toUpperCase();
-			if (uppercaseString.startsWith("KEY")) {
-				int index = Integer.parseInt(uppercaseString.replace("KEY", ""));
-				namesToIndex.put(entry.getValue(), index);
+			if (!entry.getKey().contains("visible")) {
+				namesToValues.put(entry.getKey(), entry.getValue());
 			}
 		}
 
-		return namesToIndex;
+		return namesToValues;
 	}
 }

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/SectionGrid.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/SectionGrid.java
@@ -150,7 +150,7 @@ public class SectionGrid {
 		rowsToUpdate = new ArrayList<>();
 		rowsToDelete = new ArrayList<>();
 
-		setKeysToIndex(new HashMap<>());
+		setFieldnameToValue(new HashMap<>());
 	}
 
 	public void createGrid() {
@@ -511,7 +511,7 @@ public class SectionGrid {
 		return fieldnameToValue;
 	}
 
-	public void setKeysToIndex(Map<String, String> fieldnameToValue) {
+	public void setFieldnameToValue(Map<String, String> fieldnameToValue) {
 		this.fieldnameToValue = fieldnameToValue;
 	}
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/SectionGrid.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/SectionGrid.java
@@ -124,7 +124,7 @@ public class SectionGrid {
 
 	private GridAccessor gridAccessor;
 
-	private Map<String, Integer> keynameToIndex;
+	private Map<String, String> fieldnameToValue;
 
 	private List<Row> rowsToInsert;
 	private List<Row> rowsToUpdate;
@@ -495,23 +495,22 @@ public class SectionGrid {
 		updateNatTable();
 	}
 
-	public Map<String, Integer> getKeysToIndex() {
-		return keynameToIndex;
+	public Map<String, String> getFieldnameToValue() {
+		return fieldnameToValue;
 	}
 
-	public void setKeysToIndex(Map<String, Integer> keynameToIndex) {
-		this.keynameToIndex = keynameToIndex;
+	public void setKeysToIndex(Map<String, String> fieldnameToValue) {
+		this.fieldnameToValue = fieldnameToValue;
 	}
 
 	public void setPrimaryKeys(Map<String, Value> primaryKeys) {
 		for (Row r : dataTable.getRows()) {
 
-			if (!getKeysToIndex().isEmpty()) { // Zuordnung aus .xbs nutzen
+			if (!getFieldnameToValue().isEmpty()) { // Zuordnung aus .xbs nutzen
 
 				for (Field f : grid.getField()) {
-					if (getKeysToIndex().containsKey(f.getName())) {
-						int index = getKeysToIndex().get(f.getName());
-						Value v = mDetail.getPrimaryFields().get(index).getValue();
+					if (getFieldnameToValue().containsKey(f.getName())) {
+						Value v = mDetail.getField(getFieldnameToValue().get(f.getName())).getValue();
 						r.setValue(v, grid.getField().indexOf(f));
 					}
 				}


### PR DESCRIPTION
Neues Format der application.xbs wird genutzt, closes #825

Außerdem
- Felder in OPs haben Namen <OPName>.<FieldName>
- Auch für Grids in der Hauptmaske wird .xbs auch Keyzuordnung überprüft, closes #835

Werte mit "@" direkt einsetzen ist noch nicht umgesetzt, da noch kein Beispiel.