### PR TITLE
JRE automatisch beim Bauen der Anwednung einpacken

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
 							<version>1.0.1-SNAPSHOT</version>
 						</artifact>
 					</target>
+					<resolveWithExecutionEnvironmentConstraints>false</resolveWithExecutionEnvironmentConstraints>
 					<!-- end::target-definition[] -->
 					<environments>
 						<environment>

--- a/releng/aero.minova.rcp.product/aero.minova.rcp.rcp.product
+++ b/releng/aero.minova.rcp.product/aero.minova.rcp.rcp.product
@@ -108,6 +108,7 @@
       <feature id="org.eclipse.e4.rcp" installMode="root"/>
       <feature id="org.eclipse.emf.ecore" installMode="root"/>
       <feature id="org.eclipse.emf.common" installMode="root"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.full" installMode="root"/>
    </features>
 
    <configurations>

--- a/releng/target-definition/eclipse-2021-03.target
+++ b/releng/target-definition/eclipse-2021-03.target
@@ -63,6 +63,11 @@
         ​<unit id="org.eclipse.swtbot.nebula.nattable.finder" version="0.0.0"/>
 	</location>
 	
+	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/justj/jres/11/updates/release"/>
+		<unit id="org.eclipse.justj.openjdk.hotspot.jre.full.feature.group" version="0.0.0"/>
+	</location>
+	
 </locations>
 
 


### PR DESCRIPTION
Aktuell packen wir das full JRE 11 mit ein. Das minimal JRE von der
Update Site geht nicht, da dann JaxB fehlt und JRE 16 / JRE 17 setzt
voraus, das die Applikation auf Java 17 migriert wird.

Fixes #644