### PR TITLE
UI Persistieren

### DIFF
--- a/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
+++ b/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
@@ -95,7 +95,11 @@ public class Constants {
 	public static final String SEARCHCRITERIA_DEFAULT = "DEFAULT";
 	public static final String LAST_LOADED_SEARCHCRITERIA = "aero.minova.rcp.preferences.lastsearchcriteria";
 	public static final String LAST_SEARCHCRITERIA = "LastLoadedSearchCriteria";
+
+	// Wiederherstellen der UI
 	public static final String LAST_STATE = "LAST_STATE";
+	public static final String RESTORING_UI_MESSAGE_SHOWN_THIS_SESSION = "RestoringUIMessageShownThisSession";
+	public static final String NEVER_SHOW_RESTORING_UI_MESSAGE = "NeverShowRestoringUIMessage";
 
 	// NatTable Label
 	public static final String COMPARATOR_LABEL = "CUSTOM_COMPARATOR_LABEL"; // Für eigene Sortierung

--- a/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
+++ b/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
@@ -2,6 +2,11 @@ package aero.minova.rcp.constants;
 
 public class Constants {
 
+	// Parts
+	public static final String SEARCH_PART = "aero.minova.rcp.rcp.part.search";
+	public static final String INDEX_PART = "aero.minova.rcp.rcp.part.index";
+	public static final String DETAIL_PART = "aero.minova.rcp.rcp.part.details";
+
 	public static final String TABLE_KEYTEXT = "KeyText";
 	public static final String TABLE_KEYLONG = "KeyLong";
 	public static final String TABLE_DESCRIPTION = "Description";
@@ -90,6 +95,7 @@ public class Constants {
 	public static final String SEARCHCRITERIA_DEFAULT = "DEFAULT";
 	public static final String LAST_LOADED_SEARCHCRITERIA = "aero.minova.rcp.preferences.lastsearchcriteria";
 	public static final String LAST_SEARCHCRITERIA = "LastLoadedSearchCriteria";
+	public static final String LAST_STATE = "LAST_STATE";
 
 	// NatTable Label
 	public static final String COMPARATOR_LABEL = "CUSTOM_COMPARATOR_LABEL"; // Für eigene Sortierung

--- a/bundles/aero.minova.rcp.core/src/aero/minova/rcp/core/ui/PartsID.java
+++ b/bundles/aero.minova.rcp.core/src/aero/minova/rcp/core/ui/PartsID.java
@@ -1,7 +1,0 @@
-package aero.minova.rcp.core.ui;
-
-public class PartsID {
-	public static final String SEARCH_PART = "aero.minova.rcp.rcp.part.search";
-	public static final String INDEX_PART = "aero.minova.rcp.rcp.part.index";
-	public static final String DETAIL_PART = "aero.minova.rcp.rcp.part.details";
-}

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/ClearSearchHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/ClearSearchHandler.java
@@ -12,7 +12,6 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 
 import aero.minova.rcp.constants.Constants;
-import aero.minova.rcp.core.ui.PartsID;
 import aero.minova.rcp.rcp.parts.WFCSearchPart;
 
 public class ClearSearchHandler {
@@ -25,8 +24,8 @@ public class ClearSearchHandler {
 
 	@Execute
 	public void execute(MPerspective mPerspective) {
-		List<MPart> findElements = model.findElements(mPerspective, PartsID.SEARCH_PART, MPart.class);
-		broker.post(Constants.BROKER_DELETEROWSEARCHTABLE, PartsID.SEARCH_PART);
+		List<MPart> findElements = model.findElements(mPerspective, Constants.SEARCH_PART, MPart.class);
+		broker.post(Constants.BROKER_DELETEROWSEARCHTABLE, Constants.SEARCH_PART);
 	}
 
 	@CanExecute

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/LoadIndexHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/LoadIndexHandler.java
@@ -18,7 +18,6 @@ import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.swt.widgets.Shell;
 
 import aero.minova.rcp.constants.Constants;
-import aero.minova.rcp.core.ui.PartsID;
 import aero.minova.rcp.dataservice.IDataService;
 import aero.minova.rcp.model.Table;
 import aero.minova.rcp.model.util.ErrorObject;
@@ -48,7 +47,7 @@ public class LoadIndexHandler {
 		loading = true;
 		broker.post(UIEvents.REQUEST_ENABLEMENT_UPDATE_TOPIC, UIEvents.ALL_ELEMENT_ID);
 
-		List<MPart> findElements = model.findElements(perspective, PartsID.SEARCH_PART, MPart.class);
+		List<MPart> findElements = model.findElements(perspective, Constants.SEARCH_PART, MPart.class);
 		((WFCSearchPart) findElements.get(0).getObject()).saveNattable();
 		((WFCSearchPart) findElements.get(0).getObject()).updateUserInput();
 		Table searchTable = (Table) findElements.get(0).getContext().get("NatTableDataSearchArea");

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/SearchCriteriaLoadHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/SearchCriteriaLoadHandler.java
@@ -19,11 +19,11 @@ import org.eclipse.e4.ui.model.application.ui.menu.MMenuElement;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.osgi.service.prefs.BackingStoreException;
 
+import aero.minova.rcp.constants.Constants;
 import aero.minova.rcp.model.Table;
 import aero.minova.rcp.rcp.parts.WFCSearchPart;
 
 public class SearchCriteriaLoadHandler {
-
 
 	@Inject
 	@Preference
@@ -39,7 +39,7 @@ public class SearchCriteriaLoadHandler {
 			data = ((WFCSearchPart) part).getData();
 		}
 
-		if(data != null) {
+		if (data != null) {
 			try {
 				String[] keys = prefs.keys();
 				List<String> keyList = new ArrayList<>();
@@ -48,10 +48,11 @@ public class SearchCriteriaLoadHandler {
 				}
 				Collections.sort(keyList);
 				for (String s : keyList) {
-					if(s.endsWith(".table") && s.startsWith(data.getName()+".")) {
+					if (s.endsWith(".table") && s.startsWith(data.getName() + ".")) {
 						MHandledMenuItem item = createMenuItem(service, s);
-						prefs.get(s, null);
+						if (!item.getLabel().equals(Constants.LAST_STATE)) { // Last_State ist nur zum wiederherstellen der UI
 							items.add(item);
+						}
 					}
 				}
 			} catch (BackingStoreException e) {
@@ -69,19 +70,19 @@ public class SearchCriteriaLoadHandler {
 		// vWorkingTime.erlanger Heute
 		// erlanger Heute
 		String displayName = criteriaTableName.replace(".table", "");
-		displayName = displayName.substring(displayName.indexOf(".") + 1, displayName.length());
+		displayName = displayName.substring(displayName.lastIndexOf(".") + 1, displayName.length());
 		mi.setLabel(displayName);
 
 		final MCommand cmd = MCommandsFactory.INSTANCE.createCommand();
 		cmd.setElementId("aero.minova.rcp.rcp.command.searchCriteria");
 		mi.setCommand(cmd);
 
-		//action
+		// action
 		MParameter param = MCommandsFactory.INSTANCE.createParameter();
 		param.setName("aero.minova.rcp.rcp.commandparameter.criteriaaction");
 		param.setValue("LOAD");
 		mi.getParameters().add(param);
-		//Name
+		// Name
 		param = MCommandsFactory.INSTANCE.createParameter();
 		param.setName("aero.minova.rcp.rcp.commandparameter.criterianame");
 		param.setValue(displayName);

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/SearchCriteriaSaveHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/SearchCriteriaSaveHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.e4.ui.model.application.ui.menu.MMenuElement;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.osgi.service.prefs.BackingStoreException;
 
+import aero.minova.rcp.constants.Constants;
 import aero.minova.rcp.model.Table;
 import aero.minova.rcp.rcp.parts.WFCSearchPart;
 
@@ -49,7 +50,9 @@ public class SearchCriteriaSaveHandler {
 				for (String s : keyList) {
 					if (s.endsWith(".table") && s.startsWith(data.getName() + ".")) {
 						MHandledMenuItem md = createMenuItem(service, s);
-						items.add(md);
+						if (!md.getLabel().equals(Constants.LAST_STATE)) { // Last_State ist nur zum wiederherstellen der UI
+							items.add(md);
+						}
 					}
 				}
 			} catch (BackingStoreException e) {
@@ -60,7 +63,6 @@ public class SearchCriteriaSaveHandler {
 
 	}
 
-
 	private MHandledMenuItem createMenuItem(EModelService service, String criteriaTableName) {
 		MHandledMenuItem mi = service.createModelElement(MHandledMenuItem.class);
 		// Name aus dem Eintrag suchen!
@@ -68,7 +70,7 @@ public class SearchCriteriaSaveHandler {
 		// vWorkingTime.erlanger Heute
 		// erlanger Heute
 		String displayName = criteriaTableName.replace(".table", "");
-		displayName = displayName.substring(displayName.indexOf(".") + 1, displayName.length());
+		displayName = displayName.substring(displayName.lastIndexOf(".") + 1, displayName.length());
 		mi.setLabel(displayName);
 
 		final MCommand cmd = MCommandsFactory.INSTANCE.createCommand();

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/SelectDetailPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/SelectDetailPart.java
@@ -10,7 +10,7 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
 
-import aero.minova.rcp.core.ui.PartsID;
+import aero.minova.rcp.constants.Constants;
 import aero.minova.rcp.model.form.MField;
 import aero.minova.rcp.rcp.accessor.AbstractValueAccessor;
 import aero.minova.rcp.rcp.parts.WFCDetailPart;
@@ -25,11 +25,11 @@ public class SelectDetailPart {
 
 	@Execute
 	public void execute(MPerspective mPerspective) {
-		List<MPart> findElements = model.findElements(mPerspective, PartsID.DETAIL_PART, MPart.class);
+		List<MPart> findElements = model.findElements(mPerspective, Constants.DETAIL_PART, MPart.class);
 		MPart part = findElements.get(0);
 		partService.activate(part);
 		WFCDetailPart detailPart = (WFCDetailPart) part.getObject();
 		MField field = detailPart.getDetail().getPageList().get(0).getTabList().get(0);
-		((AbstractValueAccessor)field.getValueAccessor()).getControl().setFocus();
+		((AbstractValueAccessor) field.getValueAccessor()).getControl().setFocus();
 	}
 }

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/SelectSearchPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/SelectSearchPart.java
@@ -13,11 +13,11 @@ import org.eclipse.nebula.widgets.nattable.NatTable;
 import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer;
 import org.eclipse.nebula.widgets.nattable.selection.command.SelectCellCommand;
 
-import aero.minova.rcp.core.ui.PartsID;
+import aero.minova.rcp.constants.Constants;
 import aero.minova.rcp.rcp.parts.WFCSearchPart;
 
 public class SelectSearchPart {
-	
+
 	@Inject
 	private EModelService model;
 
@@ -26,7 +26,7 @@ public class SelectSearchPart {
 
 	@Execute
 	public void execute(MPerspective mPerspective) {
-		List<MPart> findElements = model.findElements(mPerspective, PartsID.SEARCH_PART, MPart.class);
+		List<MPart> findElements = model.findElements(mPerspective, Constants.SEARCH_PART, MPart.class);
 		MPart part = findElements.get(0);
 		partService.activate(part);
 		WFCSearchPart searchPart = (WFCSearchPart) part.getObject();

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCDetailPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCDetailPart.java
@@ -45,6 +45,7 @@ import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
 import org.eclipse.e4.ui.workbench.modeling.IWindowCloseHandler;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
@@ -139,6 +140,10 @@ public class WFCDetailPart extends WFCFormPart implements ValueChangeListener, G
 	@Preference(nodePath = ApplicationPreferences.PREFERENCES_NODE, value = ApplicationPreferences.SELECT_ALL_CONTROLS)
 	boolean selectAllControls;
 
+	@Inject
+	@Preference
+	private IEclipsePreferences prefs;
+
 	IEclipsePreferences prefsDetailSections = InstanceScope.INSTANCE.getNode(Constants.PREFERENCES_DETAILSECTIONS);
 
 	@Inject
@@ -204,6 +209,7 @@ public class WFCDetailPart extends WFCFormPart implements ValueChangeListener, G
 		}
 
 		// Handler, der Dialog anzeigt wenn versucht wird, die Anwendung mit ungespeicherten Änderungen zu schließen
+		// Außerdem wird "RESTORING_UI_MESSAGE_SHOWN_THIS_SESSION" wieder auf false gesetzt, damit die Nachricht beim nächsten Starten wieder angezeigt wird
 		IWindowCloseHandler handler = mWindow -> {
 			@SuppressWarnings("unchecked")
 			List<MPerspective> pList = (List<MPerspective>) appContext.get(Constants.DIRTY_PERSPECTIVES);
@@ -216,11 +222,40 @@ public class WFCDetailPart extends WFCFormPart implements ValueChangeListener, G
 						translationService.translate("@msg.Close.DirtyMessage", null) + listString, MessageDialog.CONFIRM,
 						new String[] { translationService.translate("@Action.Discard", null), translationService.translate("@Abort", null) }, 0);
 
-				return dialog.open() == 0;
+				boolean res = dialog.open() == 0;
+				if (res) {
+					prefs.put(Constants.RESTORING_UI_MESSAGE_SHOWN_THIS_SESSION, "false");
+				}
+				return res;
 			}
+			prefs.put(Constants.RESTORING_UI_MESSAGE_SHOWN_THIS_SESSION, "false");
+
 			return true;
 		};
 		window.getContext().set(IWindowCloseHandler.class, handler);
+
+		openRestoringUIDialog();
+	}
+
+	/**
+	 * Öffnet des "UI wird wiederhergestellt" Dialog, wenn er diese Session noch nicht geöffnet wurde und die Checkbox "NEVER_SHOW_RESTORING_UI_MESSAGE" nie
+	 * gewählt wurde
+	 */
+	private void openRestoringUIDialog() {
+		boolean neverShow = prefs.getBoolean(Constants.NEVER_SHOW_RESTORING_UI_MESSAGE, false);
+		boolean shownThisSession = prefs.getBoolean(Constants.RESTORING_UI_MESSAGE_SHOWN_THIS_SESSION, false);
+
+		if (!neverShow && !shownThisSession) {
+			MessageDialogWithToggle mdwt = MessageDialogWithToggle.openInformation(Display.getCurrent().getActiveShell(), //
+					translationService.translate("@RestoringUIDialog.Title", null), //
+					translationService.translate("@RestoringUIDialog.InfoText", null), //
+					translationService.translate("@RestoringUIDialog.NeverShowAgain", null), //
+					false, null, null);
+			if (mdwt.getToggleState()) {
+				prefs.put(Constants.NEVER_SHOW_RESTORING_UI_MESSAGE, "true");
+			}
+			prefs.put(Constants.RESTORING_UI_MESSAGE_SHOWN_THIS_SESSION, "true");
+		}
 	}
 
 	private static class HeadOrPageOrGridWrapper {

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCDetailPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCDetailPart.java
@@ -244,8 +244,11 @@ public class WFCDetailPart extends WFCFormPart implements ValueChangeListener, G
 	private void openRestoringUIDialog() {
 		boolean neverShow = prefs.getBoolean(Constants.NEVER_SHOW_RESTORING_UI_MESSAGE, false);
 		boolean shownThisSession = prefs.getBoolean(Constants.RESTORING_UI_MESSAGE_SHOWN_THIS_SESSION, false);
+		// Benötigt für UI-Tests damit sich in ihnen Dialog nicht öffnet, wird in LifeCycle gesetzt
+		boolean neverShowContext = appContext.get(Constants.NEVER_SHOW_RESTORING_UI_MESSAGE) != null
+				&& (boolean) appContext.get(Constants.NEVER_SHOW_RESTORING_UI_MESSAGE);
 
-		if (!neverShow && !shownThisSession) {
+		if (!neverShow && !shownThisSession && !neverShowContext) {
 			MessageDialogWithToggle mdwt = MessageDialogWithToggle.openInformation(Display.getCurrent().getActiveShell(), //
 					translationService.translate("@RestoringUIDialog.Title", null), //
 					translationService.translate("@RestoringUIDialog.InfoText", null), //

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCDetailPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCDetailPart.java
@@ -34,6 +34,7 @@ import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.di.extensions.Preference;
 import org.eclipse.e4.core.di.extensions.Service;
 import org.eclipse.e4.core.services.translation.TranslationService;
+import org.eclipse.e4.ui.di.PersistState;
 import org.eclipse.e4.ui.di.UISynchronize;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
@@ -178,6 +179,7 @@ public class WFCDetailPart extends WFCFormPart implements ValueChangeListener, G
 	@Inject
 	EModelService eModelService;
 	MApplication mApplication;
+	private List<SectionGrid> sectionGrids = new ArrayList<>();
 
 	@PostConstruct
 	public void postConstruct(Composite parent, MWindow window, MApplication mApp) {
@@ -728,6 +730,7 @@ public class WFCDetailPart extends WFCFormPart implements ValueChangeListener, G
 					gA.setSectionGrid(sg);
 					mGrid.setGridAccessor(gA);
 					mSection.getmDetail().putGrid(mGrid);
+					sectionGrids.add(sg);
 
 					ContextInjectionFactory.inject(sg, context); // In Context injected, damit Injection in der Klasse verfügbar ist
 					sg.createGrid();
@@ -949,6 +952,13 @@ public class WFCDetailPart extends WFCFormPart implements ValueChangeListener, G
 			if (this.dirtyFlag != setDirty) {
 				setDirtyFlag(setDirty);
 			}
+		}
+	}
+
+	@PersistState
+	public void persistState() {
+		for (SectionGrid sg : sectionGrids) {
+			sg.saveState();
 		}
 	}
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCSearchPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCSearchPart.java
@@ -268,10 +268,7 @@ public class WFCSearchPart extends WFCFormPart {
 	@LoadTableSelection
 	public void loadPrefs(@Named("ConfigName") String name) {
 
-		// Close Editor
-		if (natTable.getActiveCellEditor() != null) {
-			natTable.getActiveCellEditor().close();
-		}
+		natTable.commitAndCloseActiveCellEditor();
 
 		String tableName = form.getIndexView().getSource();
 		String string = prefs.get(tableName + "." + name + ".table", null);
@@ -333,10 +330,8 @@ public class WFCSearchPart extends WFCFormPart {
 		if (!mPart.equals(this.mPart)) {
 			return;
 		}
-		// Close Editor
-		if (natTable.getActiveCellEditor() != null) {
-			natTable.getActiveCellEditor().close();
-		}
+
+		natTable.commitAndCloseActiveCellEditor();
 
 		// Alle Einträge entfernen
 		getData().getRows().clear();
@@ -358,10 +353,8 @@ public class WFCSearchPart extends WFCFormPart {
 				rows2delete.add(sortedList.get(i));
 			}
 		}
-		// Close Editor
-		if (natTable.getActiveCellEditor() != null) {
-			natTable.getActiveCellEditor().close();
-		}
+
+		natTable.commitAndCloseActiveCellEditor();
 		deleteSearchRows(rows2delete);
 		refreshNatTable();
 	}

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCSearchPart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCSearchPart.java
@@ -15,6 +15,7 @@ import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.di.extensions.Preference;
 import org.eclipse.e4.core.services.translation.TranslationService;
+import org.eclipse.e4.ui.di.PersistState;
 import org.eclipse.e4.ui.di.UIEventTopic;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.jface.layout.GridDataFactory;
@@ -117,7 +118,7 @@ public class WFCSearchPart extends WFCFormPart {
 
 		natTable = createNatTable(parent, form, getData());
 
-		loadPrefs(Constants.SEARCHCRITERIA_DEFAULT);
+		loadPrefs(Constants.LAST_STATE);
 	}
 
 	/**
@@ -229,11 +230,23 @@ public class WFCSearchPart extends WFCFormPart {
 		return natTable;
 	}
 
+	@PersistState
+	public void persistState() {
+		savePrefs(true, Constants.LAST_STATE);
+	}
+
+	/**
+	 * xxx.table -> Inhalt der Tabelle <br>
+	 * xxx.search.size (index,breite(int)) -> Speichert auch Reihenfolge der Spalten <br>
+	 * Ähnlich im IndexPart
+	 * 
+	 * @param saveRowConfig
+	 * @param name
+	 * @param perspective
+	 */
 	@PersistTableSelection
-	public void savePrefs(@Named("SaveRowConfig") Boolean saveRowConfig, @Named("ConfigName") String name) {
-		// xxx.table
-		// xxx.search.size (index,breite(int)), Speichert auch Reihenfolge der Spalten
-		// Ähnlich im IndexPart
+	public void savePrefs(@Named("SaveRowConfig") boolean saveRowConfig, @Named("ConfigName") String name) {
+
 		saveNattable();
 		String tableName = getData().getName();
 		prefs.put(tableName + "." + name + ".table", mjs.table2Json(getData(), true));
@@ -254,6 +267,7 @@ public class WFCSearchPart extends WFCFormPart {
 
 	@LoadTableSelection
 	public void loadPrefs(@Named("ConfigName") String name) {
+
 		// Close Editor
 		if (natTable.getActiveCellEditor() != null) {
 			natTable.getActiveCellEditor().close();

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/WFCDetailCASRequestsUtil.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/WFCDetailCASRequestsUtil.java
@@ -35,7 +35,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
 import aero.minova.rcp.constants.Constants;
-import aero.minova.rcp.core.ui.PartsID;
 import aero.minova.rcp.dataservice.IDataFormService;
 import aero.minova.rcp.dataservice.IDataService;
 import aero.minova.rcp.form.model.xsd.Column;
@@ -603,7 +602,7 @@ public class WFCDetailCASRequestsUtil {
 		MPerspective activePerspective = model.getActivePerspective(partContext.get(MWindow.class));
 		if (activePerspective.equals(perspective)) {
 			// Fokus auf den Search Part legen, damit Fehlermeldungen nicht mehrmals angezeigt werden
-			List<MPart> findElements = model.findElements(activePerspective, PartsID.SEARCH_PART, MPart.class);
+			List<MPart> findElements = model.findElements(activePerspective, Constants.SEARCH_PART, MPart.class);
 			partService.activate(findElements.get(0));
 
 			MessageDialog.openError(shell, ERROR, getTranslation(message));
@@ -632,7 +631,7 @@ public class WFCDetailCASRequestsUtil {
 			value += "\nProcedure/View: " + et.getProcedureOrView();
 
 			// Fokus auf den Search Part legen, damit Fehlermeldungen von Lookups nicht mehrmals angezeigt werden
-			List<MPart> findElements = model.findElements(activePerspective, PartsID.SEARCH_PART, MPart.class);
+			List<MPart> findElements = model.findElements(activePerspective, Constants.SEARCH_PART, MPart.class);
 			partService.activate(findElements.get(0));
 
 			if (et.getT() == null) {

--- a/bundles/aero.minova.rcp.workspace/src/aero/minova/rcp/workspace/LifeCycle.java
+++ b/bundles/aero.minova.rcp.workspace/src/aero/minova/rcp/workspace/LifeCycle.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.widgets.Display;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
+import aero.minova.rcp.constants.Constants;
 import aero.minova.rcp.dataservice.IDataService;
 import aero.minova.rcp.preferences.WorkspaceAccessPreferences;
 import aero.minova.rcp.translate.lifecycle.Manager;
@@ -56,6 +57,8 @@ public class LifeCycle {
 		for (String string : applicationArgs) {
 			if (string.startsWith("-user=")) {
 				argUser = string.substring(string.indexOf("=") + 1);
+				// In UI-Tests darf sich der Dialog nicht öffnen
+				workbenchContext.set(Constants.NEVER_SHOW_RESTORING_UI_MESSAGE, true);
 			}
 			if (string.startsWith("-pw=")) {
 				argPW = string.substring(string.indexOf("=") + 1);


### PR DESCRIPTION
Neben dem Persistieren der UI (der NatTables) inkl. Dialog folgende Änderungen:
* Konstanten für Partnamen in `Constants` Klasse verschoben, `PartsID` Klasse gelöscht
* Beim Speichern/Laden von Suchkriterien wird der Indexpart wie der Suchpart über Injections statt über Broker aufgerufen

closes #848