### PR TITLE
Druck unter Windows mit Vorschau

### DIFF
--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
@@ -298,7 +298,7 @@ public class DataService implements IDataService {
 			log("CAS Answer XML Detail:\n" + t.body());
 			SqlProcedureResult fromJson = gson.fromJson(t.body(), SqlProcedureResult.class);
 			try {
-				FileWriter fw = new FileWriter(path.toFile());
+				FileWriter fw = new FileWriter(path.toFile(), StandardCharsets.UTF_8);
 				fw.write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
 				fw.write("<" + rootElement + ">");
 				for (Row r : fromJson.getResultSet().getRows()) {

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
@@ -225,8 +225,7 @@ public class PrintIndexHandler {
 					Files.delete(pathXML);
 				}
 
-				// Auf Windows gibt es Probleme mit der internen Vorschau, deshalb immer deaktiviert
-				if (disablePreview || System.getProperty("os.name").startsWith("Win")) {
+				if (disablePreview) {
 					PrintUtil.showFile(urlPDF.toString(), null);
 				} else {
 					PrintUtil.showFile(urlPDF.toString(), PrintUtil.checkPreview(window, modelService, partService, preview));

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintIndexHandler.java
@@ -16,6 +16,7 @@ import java.util.Locale;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.xml.transform.TransformerException;
 
 import org.eclipse.e4.core.di.annotations.CanExecute;
 import org.eclipse.e4.core.di.annotations.Execute;
@@ -38,7 +39,9 @@ import org.eclipse.nebula.widgets.nattable.resize.MaxCellBoundsHelper;
 import org.eclipse.nebula.widgets.nattable.summaryrow.FixedSummaryRowLayer;
 import org.eclipse.nebula.widgets.nattable.util.GCFactory;
 import org.eclipse.swt.graphics.FontData;
+import org.xml.sax.SAXException;
 
+import aero.minova.rcp.constants.Constants;
 import aero.minova.rcp.dataservice.IDataService;
 import aero.minova.rcp.model.Column;
 import aero.minova.rcp.model.DataType;
@@ -218,6 +221,9 @@ public class PrintIndexHandler {
 				IOUtil.saveLoud(xml.toString(), pathXML.toString(), "UTF-8");
 				IOUtil.saveLoud(xslString, pathXSL.toString(), "UTF-8");
 
+				// Wenn ein file schon geladen wurde muss dieses erst freigegeben werden (unter Windows)
+				PrintUtil.checkPreview(window, modelService, partService, preview);
+
 				PrintUtil.generatePDF(urlPDF, xml.toString(), pathXSL.toFile());
 
 				if (!createXmlXsl) {
@@ -230,8 +236,9 @@ public class PrintIndexHandler {
 				} else {
 					PrintUtil.showFile(urlPDF.toString(), PrintUtil.checkPreview(window, modelService, partService, preview));
 				}
-			} catch (IOException e) {
+			} catch (IOException | SAXException | TransformerException e) {
 				e.printStackTrace();
+				broker.post(Constants.BROKER_SHOWERRORMESSAGE, translationService.translate("@msg.ErrorShowingFile", null));
 			}
 
 		}

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/PDFGenerator.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/PDFGenerator.java
@@ -2,8 +2,9 @@ package aero.minova.rcp.rcp.util;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
 import javax.xml.transform.Result;
@@ -27,9 +28,10 @@ public class PDFGenerator {
 
 	private PDFGenerator() {}
 
-	public static void createPdfFile(String xmlDataString, File stylesheet, OutputStream pdfOutputStream)
-			throws IOException, SAXException, TransformerException {
+	public static void createPdfFile(String xmlDataString, File stylesheet, URL pdf) throws IOException, SAXException, TransformerException {
 		System.out.println("Create pdf file ...");
+
+		FileOutputStream pdfOutputStream = new FileOutputStream(pdf.getFile());
 
 		FopFactory fopFactory = FopFactory.newInstance();
 		fopFactory.setBaseURL(new File(".").toURI().toURL().toString());
@@ -51,6 +53,9 @@ public class PDFGenerator {
 		Result result = new SAXResult(fop.getDefaultHandler());
 
 		transformer.transform(xmlSource, result);
+
+		pdfOutputStream.flush();
+		pdfOutputStream.close();
 	}
 
 }

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/PrintUtil.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/PrintUtil.java
@@ -1,7 +1,6 @@
 package aero.minova.rcp.rcp.util;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.text.MessageFormat;
@@ -80,23 +79,17 @@ public class PrintUtil {
 	}
 
 	/**
-	 * Generiert ein PDF Dokument und gibt es als FileOutputStream zurück!
+	 * Generiert ein PDF Dokument mithilfe der gegebenen xml und xsl
 	 *
 	 * @param pdf
 	 * @param xml
 	 * @param xsl
-	 * @return
-	 * @return
+	 * @throws TransformerException
+	 * @throws SAXException
+	 * @throws IOException
 	 */
-	public static FileOutputStream generatePDF(URL pdf, String xmlString, File stylesheet) {
-		try {
-			FileOutputStream pdfOutput = new FileOutputStream(pdf.getFile());
-			PDFGenerator.createPdfFile(xmlString, stylesheet, pdfOutput);
-			return pdfOutput;
-		} catch (IOException | SAXException | TransformerException e) {
-			e.printStackTrace();
-		}
-		return null;
+	public static void generatePDF(URL pdf, String xmlString, File stylesheet) throws IOException, SAXException, TransformerException {
+		PDFGenerator.createPdfFile(xmlString, stylesheet, pdf);
 	}
 
 }


### PR DESCRIPTION
Die Druckvorschau kann nun auch unter Windows angezeigt werden, sowohl für Indexdruck als auch für Detaildruck.
Das Problem war, dass nach dem Erstellen die PDF-Datei nicht richtig freigegeben und deshalb nicht angezeigt wurde.

closes #856