### PR TITLE
Verwendung von PlainMessageDialog um sprechende Buttontext zu haben

### DIFF
--- a/bundles/aero.minova.rcp.preferencewindow/src/aero/minova/rcp/preferencewindow/control/TextButtonForCurrentWorkspace.java
+++ b/bundles/aero.minova.rcp.preferencewindow/src/aero/minova/rcp/preferencewindow/control/TextButtonForCurrentWorkspace.java
@@ -1,6 +1,9 @@
 package aero.minova.rcp.preferencewindow.control;
 
+import static org.eclipse.jface.dialogs.PlainMessageDialog.getBuilder;
+
 import java.io.IOException;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -9,7 +12,7 @@ import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.services.log.Logger;
 import org.eclipse.e4.core.services.translation.TranslationService;
 import org.eclipse.e4.ui.workbench.IWorkbench;
-import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.dialogs.PlainMessageDialog;
 import org.eclipse.nebula.widgets.opal.preferencewindow.PreferenceWindow;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -101,9 +104,12 @@ public class TextButtonForCurrentWorkspace extends CustomPWWidget {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				Shell activeShell = Display.getCurrent().getActiveShell();
-				boolean openConfirm = MessageDialog.openConfirm(activeShell, "Neustart", translationService.translate("@msg.WFCDeleteWorkspaceRestart", null));
 
-				if (openConfirm) {
+				PlainMessageDialog confirmRestart = getBuilder(activeShell, translationService.translate("@Action.Restart", null))
+						.buttonLabels(List.of(translationService.translate("@Action.Restart", null), translationService.translate("@Abort", null)))
+						.message(translationService.translate("@msg.WFCDeleteWorkspaceRestart", null)).build();
+
+				if (confirmRestart.open() == 0) {
 					context.set(IWorkbench.PERSIST_STATE, false);
 					try {
 						FileUtils.deleteDirectory(dataService.getStoragePath().toAbsolutePath().toFile());

--- a/bundles/aero.minova.rcp.preferencewindow/src/aero/minova/rcp/preferencewindow/pages/ApplicationPreferenceWindowHandler.java
+++ b/bundles/aero.minova.rcp.preferencewindow/src/aero/minova/rcp/preferencewindow/pages/ApplicationPreferenceWindowHandler.java
@@ -1,5 +1,7 @@
 package aero.minova.rcp.preferencewindow.pages;
 
+import static org.eclipse.jface.dialogs.PlainMessageDialog.getBuilder;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -20,7 +22,7 @@ import org.eclipse.e4.ui.model.application.commands.MHandler;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.workbench.IWorkbench;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
-import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.dialogs.PlainMessageDialog;
 import org.eclipse.jface.util.Util;
 import org.eclipse.nebula.widgets.opal.preferencewindow.PWTab;
 import org.eclipse.nebula.widgets.opal.preferencewindow.PreferenceWindow;
@@ -176,10 +178,13 @@ public class ApplicationPreferenceWindowHandler {
 		if (!currentTheme.equals(newTheme) || !curentSelectAllControls == newSelectAllControls) {
 			Shell activeShell = Display.getCurrent().getActiveShell();
 
-			boolean openConfirm = MessageDialog.openConfirm(activeShell, translationService.translate("@Action.Restart", null),
-					translationService.translate("@Preferences.RestartMessage", null));
-
-			if (openConfirm) {
+			
+			PlainMessageDialog confirmRestart = getBuilder(activeShell, translationService.translate("@Action.Restart", null))
+					.buttonLabels(List.of(translationService.translate("@Action.Restart", null), translationService.translate("@Abort", null)))
+					.message(translationService.translate("@Preferences.RestartMessage", null)).build();
+			
+			int openConfirm = confirmRestart.open();
+			if (openConfirm== 0) {
 				if (!currentTheme.equals(newTheme)) {
 					updateTheme(newTheme, themeEngine, workbench);
 				} else {

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/AboutHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/AboutHandler.java
@@ -22,7 +22,6 @@ public class AboutHandler {
 				+ LocalDateTime.ofEpochSecond(lastModified / 1000, 0, ZoneOffset.UTC) + " "+ "Java Runntime: "
 				+ runtimeVersion;
 
-		// MessageDialog.openInformation(shell, "About", versionString);
 
 		final AboutDialog ad = new AboutDialog(shell, versionString);
 		ad.create();

--- a/bundles/aero.minova.rcp.workspace/src/aero/minova/rcp/workspace/LifeCycle.java
+++ b/bundles/aero.minova.rcp.workspace/src/aero/minova/rcp/workspace/LifeCycle.java
@@ -8,6 +8,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Objects;
 
 import javax.inject.Inject;
@@ -16,11 +17,13 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.services.log.Logger;
+import org.eclipse.e4.core.services.translation.TranslationService;
 import org.eclipse.e4.ui.di.UISynchronize;
 import org.eclipse.e4.ui.workbench.lifecycle.PostContextCreate;
 import org.eclipse.equinox.security.storage.ISecurePreferences;
 import org.eclipse.equinox.security.storage.StorageException;
-import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.dialogs.PlainMessageDialog;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
@@ -43,6 +46,7 @@ public class LifeCycle {
 
 	@Inject
 	IDataService dataService;
+	
 
 	@PostContextCreate
 	void postContextCreate(IEclipseContext workbenchContext) throws IllegalStateException {
@@ -107,7 +111,7 @@ public class LifeCycle {
 					workspaceLocation = loadWorkspaceConfigManually(workspaceDialog, workspaceLocation);
 				} else {
 					workspaceLocation = checkDefaultWorkspace(workspaceLocation, workspaceDialog, sPrefs);
-				}
+				}	
 			}
 		} catch (Exception e) {
 			logger.error(e);
@@ -255,9 +259,9 @@ public class LifeCycle {
 	}
 
 	private void showUserDialog() {
-		MessageDialog.openWarning(Display.getCurrent().getActiveShell(), "Reset Workspace",
-				"Due to structural changes, the application area to be loaded is reset!");
-
+		PlainMessageDialog.getBuilder(Display.getCurrent().getActiveShell(), "Reset Workspace").image(SWT.ICON_WARNING)
+		.buttonLabels(List.of("Reset", "Cancel"))
+		.message("Due to structural changes, the application area to be loaded is reset!").build().open();
 	}
 
 	private URI loadWorkspaceConfigManually(WorkspaceDialog workspaceDialog, URI workspaceLocation) {


### PR DESCRIPTION
PlainMessageDialog erlaubt es die Button text sehr leicht zu setzen.