### PR TITLE
Refactore des DataService

### DIFF
--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/IDataService.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/IDataService.java
@@ -22,20 +22,22 @@ public interface IDataService {
 	/**
 	 * Anfrage an den Server ein Table object zu bekommen, mit den Suchkriterium definiert über den searchTab
 	 *
-	 * @param tableName
 	 * @param seachTable
+	 *            Suchkriterien
 	 * @return
 	 */
-	CompletableFuture<Table> getIndexDataAsync(String tableName, Table seachTable);
-
-	CompletableFuture<SqlProcedureResult> getDetailDataAsync(String tableName, Table detailTable);
-
-	CompletableFuture<SqlProcedureResult> getGridDataAsync(String tableName, Table detailTable);
-
-	CompletableFuture<Path> getXMLAsync(String tableName, Table detailTable, String rootElement);
+	CompletableFuture<Table> getTableAsync(Table searchTable);
 
 	/**
-	 * Diese Methode löst einen Wert auf.
+	 * Anfrage an den Server um eine Prozedur aufzurufen. Die Parameter sind über die Tabelle definiert, als Prozedur-Name wird der Name der Tabelle verwendet
+	 * 
+	 * @param detailTable
+	 * @return
+	 */
+	CompletableFuture<SqlProcedureResult> callProcedureAsync(Table detailTable);
+
+	/**
+	 * Diese Methode löst einen Wert auf. Für den gegebenen keyLong und/oder keyText wird das entsprechende LookupValue angefragt
 	 *
 	 * @param field
 	 *            Über dieser Feld werden alle erforderlichen Konfigurationswerte geselesen.
@@ -43,9 +45,9 @@ public interface IDataService {
 	 *            Wenn dieser Wert true ist, werden die Daten zuerst im Cache gesucht. Werden sie dort gefunden, wird die Suche beendet. Wenn der Wert nicht im
 	 *            Cache gefunden wird, oder dieser Wert false ist, wird die Datenbank / der CAS angefragt.
 	 * @param keyLong
-	 *            Wenn dieser Wert nicht leer (null) ist, wird nach genau diesem Wert gesucht. Der Wert von KeyText wird ignoriert.
+	 *            Wenn dieser Wert nicht leer (null) ist, wird nach genau diesem Wert gesucht
 	 * @param keyText
-	 *            Der Keytext muss vollständig angegeben sein (Groß-/Kleinschreibung wir ignoriert). Er wird nur verwendet, wenn der KeyLong null ist.
+	 *            Der Keytext muss vollständig angegeben sein (Groß-/Kleinschreibung wir ignoriert)
 	 * @return
 	 */
 	CompletableFuture<List<LookupValue>> resolveLookup(MLookupField field, boolean useCache, Integer keyLong, String keyText);
@@ -53,21 +55,39 @@ public interface IDataService {
 	CompletableFuture<List<LookupValue>> resolveGridLookup(String tableName, boolean useCache);
 
 	/**
-	 * Diese Methode liefert alle möglichen Werte für den angegebenen Filtertext.
+	 * Diese Methode liefert alle möglichen Werte für das gegebene Lookup.
 	 *
 	 * @param field
 	 *            Über dieser Feld werden alle erforderlichen Konfigurationswerte geselesen.
 	 * @param useCache
 	 *            Wenn dieser Wert true ist, werden die Daten zuerst im Cache gesucht. Werden sie dort gefunden, wird die Suche beendet. Wenn der Wert nicht im
 	 *            Cache gefunden wird, oder dieser Wert false ist, wird die Datenbank / der CAS angefragt.
-	 * @param filterText
-	 *            Der Text, nach dem gefiltert werden soll. Wenn nichts angegeben wird, sollen alle möglichen Werte zurückgegeben werden. Als Wildcard sind "%"
-	 *            und "_" erlaubt, wie es im SQL-Server Standard ist.
 	 * @return
 	 */
-	CompletableFuture<List<LookupValue>> listLookup(MLookupField field, boolean useCache, String filterText);
+	CompletableFuture<List<LookupValue>> listLookup(MLookupField field, boolean useCache);
 
-	Path getStoragePath();
+	/**
+	 * Laden einer XML Datei. Diese wird im reports Ordner des Workspaces abgelegt
+	 * 
+	 * @param table
+	 *            Eine Spalte und eine Zeile, der KeyLong für die die xml Datei angefragt werden soll
+	 * @param rootElement
+	 *            Sollte aus .xbs ausgelesen werden
+	 * @return
+	 */
+	CompletableFuture<Path> getXMLAsync(Table table, String rootElement);
+
+	/**
+	 * Ersatz für die alte JavaScript Methode getSQLValue() aus Masken.
+	 * 
+	 * @param tablename
+	 * @param requestColumn
+	 * @param requestValue
+	 * @param resultColumn
+	 * @param resultType
+	 * @return
+	 */
+	CompletableFuture<Value> getSQLValue(String tablename, String requestColumn, Value requestValue, String resultColumn, DataType resultType);
 
 	CompletableFuture<String> getHashedFile(String filename);
 
@@ -76,27 +96,23 @@ public interface IDataService {
 	/**
 	 * synchrones laden einer Datei vom Server.
 	 *
-	 * @param localPath
-	 *            Lokaler Pfad für die Datei. Der Pfad vom #filename wird noch mit angehängt.
-	 * @param filename
+	 * @param serverFileName
 	 *            relativer Pfad und Dateiname auf dem Server
-	 * @return Die Datei, wenn sie geladen werden konnte; ansonsten null
 	 * @throws InterruptedException
 	 * @throws IOException
 	 */
-
 	void downloadFile(String serverFileName) throws IOException, InterruptedException;
+
+	CompletableFuture<String> getCachedFileContent(String filename);
+
+	/**
+	 * returns true if zip file could be downloaded
+	 */
+	boolean getHashedZip(String zipname);
 
 	String getUserName();
 
 	void setLogger(Logger logger);
-
-	CompletableFuture<String> getCachedFileContent(String filename);
-
-	/*
-	 * returns true if zip file could be downloaded
-	 */
-	boolean getHashedZip(String zipname);
 
 	void setTimeout(int timeout);
 
@@ -104,6 +120,6 @@ public interface IDataService {
 
 	void sendLogs();
 
-	CompletableFuture<Value> getSQLValue(String tablename, String requestColumn, Value requestValue, String resultColumn, DataType resultType);
+	Path getStoragePath();
 
 }

--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
@@ -78,6 +78,11 @@ import aero.minova.rcp.model.util.ErrorObject;
 @Component
 public class DataService implements IDataService {
 
+	/**
+	 * Wenn true wird ein String geloggt, mit dem Aufrufe direkt in der Datenbank ausgeführt werden können
+	 */
+	private boolean logSQLString = true;
+
 	EventAdmin eventAdmin;
 
 	Logger logger;
@@ -240,7 +245,7 @@ public class DataService implements IDataService {
 				.method("GET", BodyPublishers.ofString(body))//
 				.timeout(Duration.ofSeconds(timeoutDuration)).build();
 
-		log("CAS Request Index:\n" + request.toString() + "\n" + body.replaceAll("\\s", ""));
+		log("CAS Request Index:\n" + request.toString() + "\n" + body.replaceAll("\\s", ""), seachTable, false);
 
 		CompletableFuture<HttpResponse<String>> sendRequest = httpClient.sendAsync(request, BodyHandlers.ofString());
 
@@ -326,7 +331,7 @@ public class DataService implements IDataService {
 				.POST(BodyPublishers.ofString(body))//
 				.timeout(Duration.ofSeconds(timeoutDuration)).build();
 
-		log("CAS Request Detail Data:\n" + request.toString() + "\n" + body.replaceAll("\\s", ""));
+		log("CAS Request Detail Data:\n" + request.toString() + "\n" + body.replaceAll("\\s", ""), detailTable, true);
 
 		CompletableFuture<HttpResponse<String>> sendRequest = httpClient.sendAsync(request, BodyHandlers.ofString());
 
@@ -380,7 +385,7 @@ public class DataService implements IDataService {
 				.POST(BodyPublishers.ofString(body))//
 				.timeout(Duration.ofSeconds(timeoutDuration)).build();
 
-		log("CAS Request Grid Data:\n" + request.toString() + "\n" + body.replaceAll("\\s", ""));
+		log("CAS Request Grid Data:\n" + request.toString() + "\n" + body.replaceAll("\\s", ""), detailTable, true);
 
 		CompletableFuture<HttpResponse<String>> sendRequest = httpClient.sendAsync(request, BodyHandlers.ofString());
 
@@ -453,6 +458,24 @@ public class DataService implements IDataService {
 		if (LOG_CACHE) {
 			System.out.println(message);
 		}
+	}
+
+	private void log(String body, Table table, boolean procedure) {
+		String sqlString = "";
+		try {
+			if (procedure) {
+				sqlString = SQLStringUtil.prepareProcedureString(table);
+			} else {
+				sqlString = SQLStringUtil.prepareViewString(table);
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		if (logSQLString) {
+			body = body + "\n" + sqlString;
+		}
+		log(body);
 	}
 
 	private void log(String body) {

--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
@@ -1,7 +1,6 @@
 package aero.minova.rcp.dataservice.internal;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -29,7 +28,6 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -54,7 +52,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import aero.minova.rcp.constants.Constants;
-import aero.minova.rcp.dataservice.HashService;
 import aero.minova.rcp.dataservice.IDataService;
 import aero.minova.rcp.dataservice.IDummyService;
 import aero.minova.rcp.dataservice.ZipService;
@@ -70,7 +67,6 @@ import aero.minova.rcp.model.ValueDeserializer;
 import aero.minova.rcp.model.ValueSerializer;
 import aero.minova.rcp.model.builder.RowBuilder;
 import aero.minova.rcp.model.builder.TableBuilder;
-import aero.minova.rcp.model.form.MDetail;
 import aero.minova.rcp.model.form.MField;
 import aero.minova.rcp.model.form.MLookupField;
 import aero.minova.rcp.model.util.ErrorObject;
@@ -83,51 +79,14 @@ public class DataService implements IDataService {
 	 */
 	private boolean logSQLString = true;
 
-	EventAdmin eventAdmin;
-
 	Logger logger;
 
 	HashMap<String, String> serverHashes = new HashMap<>();
 
-	@Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MANDATORY)
-	void registerEventAdmin(EventAdmin admin) {
-		this.eventAdmin = admin;
-	}
-
-	void unregisterEventAdmin(EventAdmin admin) {
-		this.eventAdmin = null;
-	}
-
-	public void postError(ErrorObject value) {
-		Dictionary<String, Object> data = new Hashtable<>(2);
-		data.put(EventConstants.EVENT_TOPIC, Constants.BROKER_SHOWERROR);
-		data.put(IEventBroker.DATA, value);
-		Event event = new Event(Constants.BROKER_SHOWERROR, data);
-		eventAdmin.postEvent(event);
-
-		log("CAS error:\n" + value.getErrorTable().getRows().get(0).getValue(0).getStringValue() + "\nUser: " + value.getUser() + "\nProcedure/View: "
-				+ value.getProcedureOrView());
-	}
-
-	public void postNotification(String message) {
-		Dictionary<String, Object> data = new Hashtable<>(2);
-		data.put(EventConstants.EVENT_TOPIC, Constants.BROKER_SHOWNOTIFICATION);
-		data.put(IEventBroker.DATA, message);
-		Event event = new Event(Constants.BROKER_SHOWNOTIFICATION, data);
-		eventAdmin.postEvent(event);
-	}
-
-	public void showNoResposeServerError(String message, Throwable th) {
-		// Fehlermeldung höchstens alle minTimeBetweenError Sekunden anzeigen
-		if ((System.currentTimeMillis() - timeOfLastConnectionErrorMessage) > minTimeBetweenError * 1000) {
-			Dictionary<String, Object> data = new Hashtable<>(2);
-			data.put(EventConstants.EVENT_TOPIC, Constants.BROKER_SHOWCONNECTIONERRORMESSAGE);
-			data.put(IEventBroker.DATA, new ErrorObject(message, username, th));
-			Event event = new Event(Constants.BROKER_SHOWCONNECTIONERRORMESSAGE, data);
-			eventAdmin.postEvent(event);
-			timeOfLastConnectionErrorMessage = System.currentTimeMillis();
-		}
-	}
+	/**
+	 * Je Prozedur bzw. Tabellenneame gibt es einen Cache je KeyLong mit dem LookupValue
+	 */
+	private HashMap<String, HashMap<Integer, LookupValue>> cache = new HashMap<>();
 
 	private static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
 	private static final String CONTENT_TYPE = "Content-Type";
@@ -137,6 +96,7 @@ public class DataService implements IDataService {
 	public static final String TABLE_LASTACTION = "LastAction";
 	public static final String TABLE_COUNT = "Count";
 	public static final String TABLE_FILTERLASTACTION = "FilterLastAction";
+	public static final String ERROR = "Error";
 
 	private static int timeoutDuration = 15;
 	private static int timeoutDurationOpenNotification = 1;
@@ -153,14 +113,20 @@ public class DataService implements IDataService {
 
 	private String username = null;// "admin";
 	private String password = null;// "rqgzxTf71EAx8chvchMi";
-	// Dies ist unser üblicher Server, von welchen wir unsere Daten abfragen
 	private String server = null;// "http://publictest.minova.com:17280/cas";
 
-	// Dies ist der Server, auf welchen wir derzeit zugreifen müssen, um die
-	// Ticket-Anfragen zu versenden
-	// private String server = "https://mintest.minova.com:8084";
-
 	private URI workspacePath;
+
+	EventAdmin eventAdmin;
+
+	@Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MANDATORY)
+	void registerEventAdmin(EventAdmin admin) {
+		this.eventAdmin = admin;
+	}
+
+	void unregisterEventAdmin(EventAdmin admin) {
+		this.eventAdmin = null;
+	}
 
 	@Override
 	public void setCredentials(String username, String password, String server, URI workspacePath) {
@@ -173,39 +139,12 @@ public class DataService implements IDataService {
 		// im Falle der Unit tests haben wir keinen bundle context
 		if (FrameworkUtil.getBundle(this.getClass()) != null) {
 			BundleContext bundleContext = FrameworkUtil.getBundle(this.getClass()).getBundleContext();
-			// allow to trigger components after the service has been initialized, see
-			// WFCTranslationDownloadService#getDummyService
+			// allow to trigger components after the service has been initialized, see WFCTranslationDownloadService#getDummyService
 			bundleContext.registerService(IDummyService.class.getName(), new IDummyService(), null);
-
-		}
-	}
-
-	/**
-	 * Erstellt eine Datei falls sie existiert, wird sie geleert.
-	 *
-	 * @param path
-	 */
-	public void createFile(String path) {
-		try {
-			File file = new File(path);
-			if (!file.exists()) {
-				file.createNewFile();
-			} else {
-				if (file.delete()) {
-					file.createNewFile();
-					return;
-				}
-				FileOutputStream writer = new FileOutputStream(path);
-				writer.write(("").getBytes());
-				writer.close();
-			}
-		} catch (IOException e) {
-			e.printStackTrace();
 		}
 	}
 
 	private void init() {
-
 		try {
 			// Damit Umlaute in Username und Passwort genutzt werden können muss mit ISO_8859_1 encoded werden
 			String encodedUser = new String(username.getBytes(), StandardCharsets.ISO_8859_1.toString());
@@ -220,7 +159,6 @@ public class DataService implements IDataService {
 			httpClient = HttpClient.newBuilder()//
 					.sslContext(disabledSslVerificationContext())//
 					.authenticator(authentication).build();
-
 		} catch (UnsupportedEncodingException e) {
 			e.printStackTrace();
 		}
@@ -232,59 +170,129 @@ public class DataService implements IDataService {
 				.create();
 	}
 
-	@Override
-	public CompletableFuture<Table> getIndexDataAsync(String tableName, Table seachTable) {
-		return getIndexDataAsync(tableName, seachTable, true);
+	private static SSLContext disabledSslVerificationContext() {
+		SSLContext sslContext = null;// Remove certificate validation
+
+		TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
+			@Override
+			public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+				return null;
+			}
+
+			@Override
+			public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType) {}
+
+			@Override
+			public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType) {}
+		} };
+
+		try {
+			sslContext = SSLContext.getInstance("TLS");
+			sslContext.init(null, trustAllCerts, new SecureRandom());
+		} catch (NoSuchAlgorithmException | KeyManagementException e) {
+			throw new RuntimeException(e);
+		}
+		return sslContext;
 	}
 
-	public CompletableFuture<Table> getIndexDataAsync(String tableName, Table seachTable, boolean showErrorMessage) {
-		String body = gson.toJson(seachTable);
+	@Override
+	public CompletableFuture<Table> getTableAsync(Table seachTable) {
+		return getTableAsync(seachTable, true);
+	}
+
+	public CompletableFuture<Table> getTableAsync(Table searchTable, boolean showErrorMessage) {
+		String body = gson.toJson(searchTable);
 
 		HttpRequest request = HttpRequest.newBuilder().uri(URI.create(server + "/data/index")) //
 				.header(CONTENT_TYPE, "application/json") //
 				.method("GET", BodyPublishers.ofString(body))//
 				.timeout(Duration.ofSeconds(timeoutDuration)).build();
 
-		log("CAS Request Index:\n" + request.toString() + "\n" + body.replaceAll("\\s", ""), seachTable, false);
+		log("CAS Request Table:\n" + request.toString() + "\n" + body.replaceAll("\\s", ""), searchTable, false);
 
 		CompletableFuture<HttpResponse<String>> sendRequest = httpClient.sendAsync(request, BodyHandlers.ofString());
 
 		sendRequest.exceptionally(ex -> {
-			handleCASError(ex, "Index", showErrorMessage);
+			handleCASError(ex, "Table", showErrorMessage);
 			return null;
 		});
 
 		return sendRequest.thenApply(t -> {
 			Table fromJson = gson.fromJson(t.body(), Table.class);
-			if (fromJson.getName().equals("Error")) {
-				ErrorObject e = new ErrorObject(fromJson, username, tableName);
+			if (fromJson.getName().equals(ERROR)) {
+				ErrorObject e = new ErrorObject(fromJson, username, searchTable.getName());
 				postError(e);
 				return null;
 			}
-			log("CAS Answer Index:\n" + t.body());
+			log("CAS Answer Table:\n" + t.body());
 			return fromJson;
 		});
 	}
 
-	/**
-	 * Laden einer XML Datei
-	 *
-	 * @param tablename
-	 * @param detailTable
-	 * @return
-	 */
 	@Override
-	public CompletableFuture<Path> getXMLAsync(String tablename, Table detailTable, String rootElement) {
-		String body = gson.toJson(detailTable);
+	public CompletableFuture<SqlProcedureResult> callProcedureAsync(Table table) {
+		return callProcedureAsync(table, true);
+	}
+
+	public CompletableFuture<SqlProcedureResult> callProcedureAsync(Table table, boolean showErrorMessage) {
+		String body = gson.toJson(table);
+		HttpRequest request = HttpRequest.newBuilder().uri(URI.create(server + "/data/procedure")) //
+				.header(CONTENT_TYPE, "application/json") //
+				.POST(BodyPublishers.ofString(body))//
+				.timeout(Duration.ofSeconds(timeoutDuration)).build();
+
+		log("CAS Call Procedure:\n" + request.toString() + "\n" + body.replaceAll("\\s", ""), table, true);
+
+		CompletableFuture<HttpResponse<String>> sendRequest = httpClient.sendAsync(request, BodyHandlers.ofString());
+
+		sendRequest.exceptionally(ex -> {
+			handleCASError(ex, "Call Procedure", showErrorMessage);
+			return null;
+		});
+
+		return sendRequest.thenApply(t -> {
+			log("CAS Answer Call Procedure:\n" + t.body());
+			SqlProcedureResult fromJson = gson.fromJson(t.body(), SqlProcedureResult.class);
+			if (fromJson.getReturnCode() == null) {
+				String errorMessage = null;
+				Pattern fullError = Pattern.compile("com.microsoft.sqlserver.jdbc.SQLServerException: .*? \\| .*? \\| .*? \\| .*?\\\"");
+				Matcher m = fullError.matcher(t.body());
+				if (m.find()) {
+					errorMessage = m.group(0);
+				}
+				Pattern cutError = Pattern.compile("com.microsoft.sqlserver.jdbc.SQLServerException: .*? \\| .*? \\| .*? \\| ");
+				errorMessage = cutError.matcher(errorMessage).replaceAll("");
+				errorMessage = errorMessage.replaceAll("\"", "");
+				Table error = new Table();
+				error.setName(ERROR);
+				error.addColumn(new Column("Message", DataType.STRING));
+				error.addRow(RowBuilder.newRow().withValue(errorMessage).create());
+				fromJson = new SqlProcedureResult();
+				fromJson.setResultSet(error);
+				// FehlerCode
+				fromJson.setReturnCode(-1);
+			}
+			if (fromJson.getReturnCode() == -1 && fromJson.getResultSet() != null && ERROR.equals(fromJson.getResultSet().getName())) {
+				ErrorObject e = new ErrorObject(fromJson.getResultSet(), username, table.getName());
+				postError(e);
+				return null;
+			}
+			return fromJson;
+		});
+	}
+
+	@Override
+	public CompletableFuture<Path> getXMLAsync(Table table, String rootElement) {
+		String body = gson.toJson(table);
 		HttpRequest request = HttpRequest.newBuilder().uri(URI.create(server + "/data/procedure")) //
 				.header(CONTENT_TYPE, "application/json") //
 				.POST(BodyPublishers.ofString(body))//
 				.timeout(Duration.ofSeconds(timeoutDuration * 2)).build();
 
-		Path path = getStoragePath().resolve("reports/" + tablename + detailTable.getRows().get(0).getValue(0).getStringValue() + ".xml");
+		Path path = getStoragePath().resolve("reports/" + table.getName() + table.getRows().get(0).getValue(0).getStringValue() + ".xml");
 		try {
 			Files.createDirectories(path.getParent());
-			createFile(path.toString());
+			FileUtil.createFile(path.toString());
 
 		} catch (IOException e) {
 			e.printStackTrace();
@@ -317,171 +325,6 @@ public class DataService implements IDataService {
 			}
 			return path;
 		});
-	}
-
-	@Override
-	public CompletableFuture<SqlProcedureResult> getDetailDataAsync(String tableName, Table detailTable) {
-		return getDetailDataAsync(tableName, detailTable, true);
-	}
-
-	public CompletableFuture<SqlProcedureResult> getDetailDataAsync(String tableName, Table detailTable, boolean showErrorMessage) {
-		String body = gson.toJson(detailTable);
-		HttpRequest request = HttpRequest.newBuilder().uri(URI.create(server + "/data/procedure")) //
-				.header(CONTENT_TYPE, "application/json") //
-				.POST(BodyPublishers.ofString(body))//
-				.timeout(Duration.ofSeconds(timeoutDuration)).build();
-
-		log("CAS Request Detail Data:\n" + request.toString() + "\n" + body.replaceAll("\\s", ""), detailTable, true);
-
-		CompletableFuture<HttpResponse<String>> sendRequest = httpClient.sendAsync(request, BodyHandlers.ofString());
-
-		sendRequest.exceptionally(ex -> {
-			handleCASError(ex, "Detail Data", showErrorMessage);
-			return null;
-		});
-
-		return sendRequest.thenApply(t -> {
-			log("CAS Answer Detail Data:\n" + t.body());
-			SqlProcedureResult fromJson = gson.fromJson(t.body(), SqlProcedureResult.class);
-			if (fromJson.getReturnCode() == null) {
-				String errorMessage = null;
-				Pattern fullError = Pattern.compile("com.microsoft.sqlserver.jdbc.SQLServerException: .*? \\| .*? \\| .*? \\| .*?\\\"");
-				Matcher m = fullError.matcher(t.body());
-				if (m.find()) {
-					errorMessage = m.group(0);
-				}
-				Pattern cutError = Pattern.compile("com.microsoft.sqlserver.jdbc.SQLServerException: .*? \\| .*? \\| .*? \\| ");
-				errorMessage = cutError.matcher(errorMessage).replaceAll("");
-				errorMessage = errorMessage.replaceAll("\"", "");
-				Table error = new Table();
-				error.setName("Error");
-				error.addColumn(new Column("Message", DataType.STRING));
-				error.addRow(RowBuilder.newRow().withValue(errorMessage).create());
-				fromJson = new SqlProcedureResult();
-				fromJson.setResultSet(error);
-				// FehlerCode
-				fromJson.setReturnCode(-1);
-			}
-			if (fromJson.getReturnCode() == -1) {
-				if (fromJson.getResultSet() != null && "Error".equals(fromJson.getResultSet().getName())) {
-					ErrorObject e = new ErrorObject(fromJson.getResultSet(), username, tableName);
-					postError(e);
-					return null;
-				}
-			}
-			return fromJson;
-		});
-	}
-
-	@Override
-	public CompletableFuture<SqlProcedureResult> getGridDataAsync(String tableName, Table detailTable) {
-		return getGridDataAsync(tableName, detailTable, true);
-	}
-
-	public CompletableFuture<SqlProcedureResult> getGridDataAsync(String tableName, Table detailTable, boolean showErrorMessage) {
-		String body = gson.toJson(detailTable);
-		HttpRequest request = HttpRequest.newBuilder().uri(URI.create(server + "/data/procedure")) //
-				.header(CONTENT_TYPE, "application/json") //
-				.POST(BodyPublishers.ofString(body))//
-				.timeout(Duration.ofSeconds(timeoutDuration)).build();
-
-		log("CAS Request Grid Data:\n" + request.toString() + "\n" + body.replaceAll("\\s", ""), detailTable, true);
-
-		CompletableFuture<HttpResponse<String>> sendRequest = httpClient.sendAsync(request, BodyHandlers.ofString());
-
-		sendRequest.exceptionally(ex -> {
-			handleCASError(ex, "Grid Data", showErrorMessage);
-			return null;
-		});
-
-		return sendRequest.thenApply(t -> {
-			log("CAS Answer Grid Data:\n" + t.body());
-			SqlProcedureResult fromJson = gson.fromJson(t.body(), SqlProcedureResult.class);
-			if (fromJson.getReturnCode() == null) {
-				String errorMessage = null;
-				Pattern fullError = Pattern.compile("com.microsoft.sqlserver.jdbc.SQLServerException: .*? \\| .*? \\| .*? \\| .*?\\\"");
-				Matcher m = fullError.matcher(t.body());
-				if (m.find()) {
-					errorMessage = m.group(0);
-				}
-				Pattern cutError = Pattern.compile("com.microsoft.sqlserver.jdbc.SQLServerException: .*? \\| .*? \\| .*? \\| ");
-				errorMessage = cutError.matcher(errorMessage).replaceAll("");
-				errorMessage = errorMessage.replaceAll("\"", "");
-				Table error = new Table();
-				error.setName("Error");
-				error.addColumn(new Column("Message", DataType.STRING));
-				error.addRow(RowBuilder.newRow().withValue(errorMessage).create());
-				fromJson = new SqlProcedureResult();
-				fromJson.setResultSet(error);
-				// FehlerCode
-				fromJson.setReturnCode(-1);
-			}
-			if (fromJson.getReturnCode() == -1) {
-				if (fromJson.getResultSet() != null && "Error".equals(fromJson.getResultSet().getName())) {
-					ErrorObject e = new ErrorObject(fromJson.getResultSet(), username, tableName);
-					postError(e);
-					return null;
-				}
-			}
-			return fromJson;
-		});
-	}
-
-	private static SSLContext disabledSslVerificationContext() {
-		// Remove certificate validation
-		SSLContext sslContext = null;
-
-		TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
-
-			@Override
-			public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-				return null;
-			}
-
-			@Override
-			public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType) {}
-
-			@Override
-			public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType) {}
-		} };
-
-		try {
-			sslContext = SSLContext.getInstance("TLS");
-			sslContext.init(null, trustAllCerts, new SecureRandom());
-		} catch (NoSuchAlgorithmException | KeyManagementException e) {
-			throw new RuntimeException(e);
-		}
-		return sslContext;
-	}
-
-	private void logCache(String message) {
-		if (LOG_CACHE) {
-			System.out.println(message);
-		}
-	}
-
-	private void log(String body, Table table, boolean procedure) {
-		String sqlString = "";
-		try {
-			if (procedure) {
-				sqlString = SQLStringUtil.prepareProcedureString(table);
-			} else {
-				sqlString = SQLStringUtil.prepareViewString(table);
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-
-		if (logSQLString) {
-			body = body + "\n" + sqlString;
-		}
-		log(body);
-	}
-
-	private void log(String body) {
-		if (logger != null) {
-			logger.info(body);
-		}
 	}
 
 	@Override
@@ -521,28 +364,6 @@ public class DataService implements IDataService {
 	/**
 	 * synchrones laden einer Datei vom Server.
 	 *
-	 * @param localPath
-	 *            Lokaler Pfad für die Datei. Der Pfad vom #filename wird noch mit angehängt.
-	 * @param filename
-	 *            relativer Pfad und Dateiname auf dem Server
-	 * @return Die Datei, wenn sie geladen werden konnte; ansonsten null
-	 */
-	private CompletableFuture<String> downloadAsync(String filename) {
-		HttpRequest request = HttpRequest.newBuilder().uri(URI.create(server + "/files/read?path=" + filename))//
-				.header(CONTENT_TYPE, APPLICATION_OCTET_STREAM) //
-				.timeout(Duration.ofSeconds(timeoutDuration)).build();
-		log("CAS Request File Async:\n" + request + "\n" + filename);
-		CompletableFuture<HttpResponse<String>> sendRequest = httpClient.sendAsync(request, BodyHandlers.ofString());
-		sendRequest.exceptionally(ex -> {
-			handleCASError(ex, "File Async", true);
-			return null;
-		});
-		return sendRequest.thenApply(HttpResponse::body);
-	}
-
-	/**
-	 * synchrones laden einer Datei vom Server.
-	 *
 	 * @param filename
 	 *            relativer Pfad und Dateiname auf dem Server
 	 * @throws InterruptedException
@@ -561,6 +382,27 @@ public class DataService implements IDataService {
 		} catch (Exception e) {
 			handleCASError(e, "File Sync", false);
 		}
+	}
+
+	@Override
+	public boolean checkIfUpdateIsRequired(String fileName) throws IOException, InterruptedException {
+		File file = getStoragePath().resolve(fileName).toFile();
+		if (!file.exists()) {
+			return true;
+		}
+
+		String serverHash;
+		if (serverHashes.containsKey(fileName)) {
+			serverHash = serverHashes.get(fileName);
+		} else {
+			CompletableFuture<String> serverHashForFile = getServerHashForFile(fileName);
+			serverHash = serverHashForFile.join();
+			serverHashes.put(fileName, serverHash);
+		}
+
+		CompletableFuture<String> localHashForFile = FileUtil.getLocalHashForFile(file);
+		String localHash = localHashForFile.join();
+		return (!localHash.equals(serverHash));
 	}
 
 	/**
@@ -590,46 +432,6 @@ public class DataService implements IDataService {
 			}
 			return response;
 		}).thenApply(HttpResponse::body);
-
-	}
-
-	/**
-	 * Caller muss file.exists() aufgerufen haben
-	 *
-	 * @param file
-	 * @return
-	 */
-	public CompletableFuture<String> getLocalHashForFile(File file) {
-		return CompletableFuture.supplyAsync(() -> {
-			try {
-				return HashService.hashFile(file);
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-			return "-1";
-		});
-
-	}
-
-	@Override
-	public boolean checkIfUpdateIsRequired(String fileName) throws IOException, InterruptedException {
-		File file = getStoragePath().resolve(fileName).toFile();
-		if (!file.exists()) {
-			return true;
-		}
-
-		String serverHash;
-		if (serverHashes.containsKey(fileName)) {
-			serverHash = serverHashes.get(fileName);
-		} else {
-			CompletableFuture<String> serverHashForFile = getServerHashForFile(fileName);
-			serverHash = serverHashForFile.join();
-			serverHashes.put(fileName, serverHash);
-		}
-
-		CompletableFuture<String> localHashForFile = getLocalHashForFile(file);
-		String localHash = localHashForFile.join();
-		return (!localHash.equals(serverHash));
 	}
 
 	@Override
@@ -647,172 +449,69 @@ public class DataService implements IDataService {
 		});
 	}
 
-	private void saveFile(String fileName, CompletableFuture<String> future) {
-		future.thenAccept(s -> {
-			try {
-				File cachedFile = null;
-				try {
-					cachedFile = new File(new URI(workspacePath + fileName));
-					ensureFoldersExist(cachedFile);
-				} catch (URISyntaxException e) {
-					e.printStackTrace();
-					return;
-				}
-				Files.writeString(cachedFile.toPath(), future.join());
-				logCache("Cached file: " + fileName);
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-
-		});
-	}
-
-	static void ensureFoldersExist(File file) {
-		File folder = file.getParentFile();
-		if (!folder.exists()) {
-			if (!folder.mkdirs()) {
-				ensureFoldersExist(folder.getParentFile());
-			}
-		}
-	}
-
 	@Override
 	public Path getStoragePath() {
 		return Path.of(workspacePath);
 	}
 
-	/**
-	 * Je Prozedur bzw. Tabellenneame gibt es einen Cache je KeyLong mit dem LookupValue
-	 */
-	private HashMap<String, HashMap<Integer, LookupValue>> cache = new HashMap<>();
-
 	@Override
 	public CompletableFuture<List<LookupValue>> resolveLookup(MLookupField field, boolean useCache, Integer keyLong, String keyText) {
-		ArrayList<LookupValue> list = new ArrayList<>();
 		if (field.getLookupTable() != null) {
-			String tableName = field.getLookupTable();
-
-			HashMap<Integer, LookupValue> map = cache.computeIfAbsent(tableName, k -> new HashMap<>());
-			if (useCache) {
-				if (map.get(keyLong) != null) {
-					System.out.println("UseCache: " + tableName);
-					list.add(map.get(keyLong));
-					return CompletableFuture.supplyAsync(() -> list);
-				}
-			}
-			Table t = TableBuilder.newTable(tableName) //
-					.withColumn(TABLE_KEYLONG, DataType.INTEGER)//
-					.withColumn(TABLE_KEYTEXT, DataType.STRING)//
-					.withColumn(field.getLookupDescription(), DataType.STRING)//
-					.withColumn(TABLE_LASTACTION, DataType.INTEGER)//
-					.create();
-			Row row = RowBuilder.newRow() //
-					.withValue(keyLong) //
-					.withValue(keyText) //
-					.withValue(null) //
-					.withValue(fv) //
-					.create();
-			t.addRow(row);
-			CompletableFuture<Table> tableFuture = getIndexDataAsync(t.getName(), t, false);
-			Table ta = null;
-			try {
-				ta = tableFuture.get();
-			} catch (InterruptedException | ExecutionException e) {
-				System.out.println("Error, using Cache: " + tableName);
-				showNoResposeServerError("msg.WFCNoResponseServerUsingCache", e);
-				list.add(map.get(keyLong));
-				return CompletableFuture.supplyAsync(() -> list);
-			}
-			if (ta != null && !ta.getRows().isEmpty()) {
-				Row r = ta.getRows().get(0);
-				LookupValue lv = new LookupValue(//
-						r.getValue(0).getIntegerValue(), //
-						r.getValue(1).getStringValue(), //
-						r.getValue(2) == null ? null : r.getValue(2).getStringValue());
-				map.put(keyLong, lv);
-				list.add(lv);
-			}
-			return CompletableFuture.supplyAsync(() -> list);
+			return getLookupValuesFromTable(field.getLookupTable(), field.getLookupDescription(), keyLong, keyText, true, useCache);
 		} else {
-			// LookupProcedurePrefix
 			String procedureName = field.getLookupProcedurePrefix() + "Resolve";
-			HashMap<Integer, LookupValue> map = cache.computeIfAbsent(procedureName, k -> new HashMap<>());
-			if (useCache) {
-				if (map.get(keyLong) != null) {
-					System.out.println("UseCache: " + procedureName);
-					list.add(map.get(keyLong));
-					return CompletableFuture.supplyAsync(() -> list);
-				}
-			}
-			Table t = TableBuilder.newTable(procedureName) //
-					.withColumn(TABLE_KEYLONG, DataType.INTEGER)//
-					.withColumn(TABLE_KEYTEXT, DataType.STRING)//
-					.withColumn(TABLE_FILTERLASTACTION, DataType.BOOLEAN) //
-					.create();
-			Row row = RowBuilder.newRow() //
-					.withValue(keyLong) //
-					.withValue(keyText) //
-					.withValue(false) //
-					.create();
-			t.addRow(row);
-
-			CompletableFuture<SqlProcedureResult> tableFuture = getDetailDataAsync(t.getName(), t, false);
-			Table ta = null;
-			try {
-				ta = tableFuture.get().getResultSet();
-			} catch (InterruptedException | ExecutionException e) {
-				System.out.println("Error, using cache: " + procedureName);
-				showNoResposeServerError("msg.WFCNoResponseServerUsingCache", e);
-				list.add(map.get(keyLong));
-				return CompletableFuture.supplyAsync(() -> list);
-			}
-			if (ta != null && !ta.getRows().isEmpty()) {
-				Row r = ta.getRows().get(0);
-				LookupValue lv = new LookupValue(//
-						r.getValue(0).getIntegerValue(), //
-						r.getValue(1).getStringValue(), //
-						r.getValue(2) == null ? null : r.getValue(2).getStringValue());
-				map.put(keyLong, lv);
-				list.add(lv);
-			}
-			return CompletableFuture.supplyAsync(() -> list);
+			return getLookupValuesFromProcedure(procedureName, field, keyLong, keyText, true, useCache);
 		}
 	}
 
 	@Override
 	public CompletableFuture<List<LookupValue>> resolveGridLookup(String tableName, boolean useCache) {
+		return getLookupValuesFromTable(tableName, TABLE_DESCRIPTION, null, null, true, useCache);
+	}
+
+	@Override
+	public CompletableFuture<List<LookupValue>> listLookup(MLookupField field, boolean useCache) {
+		useCache = false;
+		if (field.getLookupTable() != null) {
+			return getLookupValuesFromTable(field.getLookupTable(), field.getLookupDescription(), null, null, false, useCache);
+		} else {
+			String procedureName = field.getLookupProcedurePrefix() + "List";
+			return getLookupValuesFromProcedure(procedureName, field, null, null, false, useCache);
+		}
+	}
+
+	private CompletableFuture<List<LookupValue>> getLookupValuesFromTable(String tableName, String lookupDescriptionColumnName, Integer keyLong, String keyText,
+			boolean resolve, boolean useCache) {
 		ArrayList<LookupValue> list = new ArrayList<>();
 		HashMap<Integer, LookupValue> map = cache.computeIfAbsent(tableName, k -> new HashMap<>());
-		if (useCache && !map.isEmpty()) {
-			System.out.println("UseCache: " + tableName);
+
+		if (useCache && !resolve && !map.isEmpty()) {
+			System.err.println("UseCache: " + tableName);
 			list.addAll(map.values());
 			return CompletableFuture.supplyAsync(() -> list);
+		} else if (useCache && map.containsKey(keyLong)) {
+			System.err.println("UseCache: " + tableName + " (" + keyLong + ")");
+			list.add(map.get(keyLong));
+			return CompletableFuture.supplyAsync(() -> list);
 		}
+
 		Table t = TableBuilder.newTable(tableName) //
 				.withColumn(TABLE_KEYLONG, DataType.INTEGER)//
 				.withColumn(TABLE_KEYTEXT, DataType.STRING)//
-				.withColumn(TABLE_DESCRIPTION, DataType.STRING)//
+				.withColumn(lookupDescriptionColumnName, DataType.STRING)//
 				.withColumn(TABLE_LASTACTION, DataType.INTEGER)//
 				.create();
 		Row row = RowBuilder.newRow() //
-				.withValue(null) //
-				.withValue(null) //
+				.withValue(keyLong) //
+				.withValue(keyText) //
 				.withValue(null) //
 				.withValue(fv) //
 				.create();
 		t.addRow(row);
 
-		CompletableFuture<Table> tableFuture = getIndexDataAsync(t.getName(), t, false);
-		Table ta = null;
+		CompletableFuture<Table> tableFuture = getTableAsync(t, false);
 		try {
-			ta = tableFuture.get();
-		} catch (Exception e) {
-			System.out.println("Error, using cache: " + tableName);
-			showNoResposeServerError("msg.WFCNoResponseServerUsingCache", e);
-			list.addAll(map.values());
-			return CompletableFuture.supplyAsync(() -> list);
-		}
-		if (ta != null) {
+			Table ta = tableFuture.get();
 			for (Row r : ta.getRows()) {
 				LookupValue lv = new LookupValue(//
 						r.getValue(0).getIntegerValue(), //
@@ -822,123 +521,75 @@ public class DataService implements IDataService {
 				map.put(lv.keyLong, lv);
 				list.add(lv);
 			}
+		} catch (Exception e) {
+			System.out.println("Error, using cache: " + tableName);
+			showNoResposeServerError("msg.WFCNoResponseServerUsingCache", e);
+			list.addAll(map.values());
 		}
+
 		return CompletableFuture.supplyAsync(() -> list);
 	}
 
-	@Override
-	public CompletableFuture<List<LookupValue>> listLookup(MLookupField field, boolean useCache, String filterText) {
-		useCache = false;
+	private CompletableFuture<List<LookupValue>> getLookupValuesFromProcedure(String procedureName, MField field, Integer keyLong, String keyText,
+			boolean resolve, boolean useCache) {
 		ArrayList<LookupValue> list = new ArrayList<>();
-		if (field.getLookupTable() != null) {
-			String tableName = field.getLookupTable();
+		String hashName = resolve ? procedureName : CacheUtil.getNameList(field);
+		HashMap<Integer, LookupValue> map = cache.computeIfAbsent(hashName, k -> new HashMap<>());
 
-			HashMap<Integer, LookupValue> map = cache.computeIfAbsent(tableName, k -> new HashMap<>());
-			if (useCache) {
-				if (!map.isEmpty()) {
-					System.out.println("UseCache: " + tableName);
-					list.addAll(map.values());
-					return CompletableFuture.supplyAsync(() -> list);
-				}
-			}
-			Table t = TableBuilder.newTable(tableName) //
-					.withColumn(TABLE_KEYLONG, DataType.INTEGER)//
-					.withColumn(TABLE_KEYTEXT, DataType.STRING)//
-					.withColumn(field.getLookupDescription(), DataType.STRING)//
-					.withColumn(TABLE_LASTACTION, DataType.INTEGER)//
-					.create();
-			Row row = RowBuilder.newRow() //
-					.withValue(null) //
-					.withValue(filterText) //
-					.withValue(null) //
-					.withValue(fv) //
-					.create();
-			t.addRow(row);
-			row = RowBuilder.newRow() //
-					.withValue(null) //
-					.withValue(null) //
-					.withValue(filterText) //
-					.withValue(fv) //
-					.create();
-			t.addRow(row);
-			CompletableFuture<Table> tableFuture = getIndexDataAsync(t.getName(), t, false);
-			Table ta = null;
-			try {
-				ta = tableFuture.get();
-			} catch (Exception e) {
-				System.out.println("Error, using cache: " + tableName);
-				showNoResposeServerError("msg.WFCNoResponseServerUsingCache", e);
-				list.addAll(map.values());
-				return CompletableFuture.supplyAsync(() -> list);
-			}
-			if (ta != null) {
-				for (Row r : ta.getRows()) {
-					LookupValue lv = new LookupValue(//
-							r.getValue(0).getIntegerValue(), //
-							r.getValue(1).getStringValue(), //
-							r.getValue(2) == null ? null : r.getValue(2).getStringValue());
-
-					map.put(lv.keyLong, lv);
-					list.add(lv);
-				}
-			}
+		if (useCache && !resolve && !map.isEmpty()) {
+			System.err.println("UseCache: " + hashName);
+			list.addAll(map.values());
 			return CompletableFuture.supplyAsync(() -> list);
-		} else {
-			// Wenn wir eine Prozedur haben müssen wie die Auswahl auf die Werte
-			// einschränken, die möglich sind. Dafür sollten die Kriterien übergeben werden
-			String hashName = CacheUtil.getNameList(field);
-			// LookupProcedurePrefix
-			String procedureName = field.getLookupProcedurePrefix() + "List";
-			HashMap<Integer, LookupValue> map = cache.computeIfAbsent(hashName, k -> new HashMap<>());
+		} else if (useCache && map.containsKey(keyLong)) {
+			System.err.println("UseCache: " + hashName + " (" + keyLong + ")");
+			list.add(map.get(keyLong));
+			return CompletableFuture.supplyAsync(() -> list);
+		}
 
-			if (useCache) {
-				if (!map.isEmpty()) {
-					System.out.println("UseCache: " + hashName);
-					list.addAll(map.values());
-					return CompletableFuture.supplyAsync(() -> list);
-				}
-			}
-			Table t = TableBuilder.newTable(procedureName) //
-					.withColumn(TABLE_COUNT, DataType.INTEGER) //
-					.withColumn(TABLE_FILTERLASTACTION, DataType.BOOLEAN) //
-					.create();
-			Row row = RowBuilder.newRow() //
-					.withValue(null) //
-					.withValue(true) // true, damit gelöschte Einträge nicht zurückgegeben werden
-					.create();
+		Table t = TableBuilder.newTable(procedureName).create();
+		Row row = RowBuilder.newRow().create();
+
+		if (resolve) {
+			t.addColumn(new Column(TABLE_KEYLONG, DataType.INTEGER));
+			row.addValue(new Value(keyLong));
+
+			t.addColumn(new Column(TABLE_KEYTEXT, DataType.STRING));
+			row.addValue(new Value(keyText));
+
+			t.addColumn(new Column(TABLE_FILTERLASTACTION, DataType.BOOLEAN));
+			row.addValue(new Value(true));
+		} else {
+			t.addColumn(new Column(TABLE_COUNT, DataType.INTEGER));
+			row.addValue(null);
+			t.addColumn(new Column(TABLE_FILTERLASTACTION, DataType.BOOLEAN));
+			row.addValue(new Value(true));
 			for (String paramName : field.getLookupParameters()) {
 				MField paramField = field.getDetail().getField(paramName);
 				t.addColumn(new Column(paramName, paramField.getDataType()));
 				row.addValue(paramField.getValue());
 			}
-			t.addRow(row);
-
-			CompletableFuture<SqlProcedureResult> tableFuture = getDetailDataAsync(t.getName(), t, false);
-			Table ta = null;
-			try {
-				ta = tableFuture.get().getResultSet();
-			} catch (InterruptedException | ExecutionException e) {
-				System.out.println("Error, using Cache: " + hashName);
-				showNoResposeServerError("msg.WFCNoResponseServerUsingCache", e);
-				list.addAll(map.values());
-				return CompletableFuture.supplyAsync(() -> list);
-			} catch (NullPointerException ex) {
-				if (LOG) {
-					System.out.println("listLookup: Wir haben ein Problem, posten es an den Benutzer, aber null ist hier in Ordnung!");
-				}
-			}
-			if (ta != null) {
-				for (Row r : ta.getRows()) {
-					LookupValue lv = new LookupValue(//
-							r.getValue(0).getIntegerValue(), //
-							r.getValue(1).getStringValue(), //
-							r.getValue(2) == null ? null : r.getValue(2).getStringValue());
-					map.put(lv.keyLong, lv);
-					list.add(lv);
-				}
-			}
-			return CompletableFuture.supplyAsync(() -> list);
 		}
+
+		t.addRow(row);
+
+		CompletableFuture<SqlProcedureResult> tableFuture = callProcedureAsync(t, false);
+		try {
+			Table ta = tableFuture.get().getResultSet();
+			for (Row r : ta.getRows()) {
+				LookupValue lv = new LookupValue(//
+						r.getValue(0).getIntegerValue(), //
+						r.getValue(1).getStringValue(), //
+						r.getValue(2) == null ? null : r.getValue(2).getStringValue());
+				map.put(lv.keyLong, lv);
+				list.add(lv);
+			}
+		} catch (Exception e) {
+			System.out.println("Error, using Cache: " + hashName);
+			showNoResposeServerError("msg.WFCNoResponseServerUsingCache", e);
+			list.addAll(map.values());
+		}
+
+		return CompletableFuture.supplyAsync(() -> list);
 	}
 
 	@Override
@@ -954,7 +605,7 @@ public class DataService implements IDataService {
 				.create();
 		t.addRow(row);
 
-		CompletableFuture<Table> tableFuture = getIndexDataAsync(t.getName(), t, false);
+		CompletableFuture<Table> tableFuture = getTableAsync(t, false);
 
 		return tableFuture.thenApply(ta -> {
 			Value v = null;
@@ -967,80 +618,6 @@ public class DataService implements IDataService {
 		});
 	}
 
-	private CompletableFuture<?> getRequestedTable(int keyLong, String keyText, MField field, String purpose) {
-		MDetail detail = field.getDetail();
-		String tableName;
-		boolean isTable = false;
-		if (field.getLookupTable() != null) {
-			tableName = field.getLookupTable();
-			isTable = true;
-		} else {
-			tableName = field.getLookupProcedurePrefix() + purpose;
-		}
-		TableBuilder tableBuilder = TableBuilder.newTable(tableName);
-		RowBuilder rowBuilder = RowBuilder.newRow();
-		if (isTable) {
-			tableBuilder = tableBuilder.withColumn(TABLE_KEYLONG, DataType.INTEGER)//
-					.withColumn(TABLE_KEYTEXT, DataType.STRING)//
-					.withColumn(field.getLookupDescription(), DataType.STRING)//
-					.withColumn(TABLE_LASTACTION, DataType.INTEGER);//
-			if (keyLong == 0) {
-				rowBuilder = rowBuilder.withValue(null);
-			} else {
-				rowBuilder = rowBuilder.withValue(keyLong);
-			}
-			rowBuilder = rowBuilder.withValue(keyText);
-			rowBuilder = rowBuilder.withValue(null);
-			rowBuilder = rowBuilder.withValue(">0");
-		} else {
-			// Reihenfolge der Werte einhalten!
-			if (!purpose.equals("List")) {
-				tableBuilder = tableBuilder//
-						.withColumn(TABLE_KEYLONG, DataType.INTEGER)//
-						.withColumn(TABLE_KEYTEXT, DataType.STRING);
-				if (keyLong == 0) {
-					rowBuilder = rowBuilder.withValue(null).withValue(keyText);
-				} else {
-					rowBuilder = rowBuilder.withValue(keyLong).withValue(null);
-				}
-			} else if (purpose.equals("List")) {
-				tableBuilder = tableBuilder.withColumn(TABLE_COUNT, DataType.INTEGER);
-				rowBuilder = rowBuilder.withValue(null);
-			}
-			tableBuilder = tableBuilder.withColumn(TABLE_FILTERLASTACTION, DataType.BOOLEAN);
-			rowBuilder = rowBuilder.withValue(false);
-
-			// Einschränken der angegebenen Optionen anhand bereits ausgewählter
-			// Optionen (Kontrakt nur für Kunde x,...)
-			// Für nicht-lookups(bookingdate)->Text übernehmen wenn nicht null
-			// bei leeren feldern ein nullfeld anhängen, alle parameter müssen für die
-			// anfrage gesetzt sein
-			if (purpose.equals("List")) {
-				List<String> parameters = field.getLookupParameters();
-				for (String param : parameters) {
-					MField parameterControl = detail.getField(param);
-					tableBuilder.withColumn(param, parameterControl.getDataType());
-					if (parameterControl.getValue() != null) {
-						rowBuilder.withValue(parameterControl.getValue().getValue());
-					} else {
-						rowBuilder.withValue(null);
-					}
-				}
-			}
-		}
-		Table t = tableBuilder.create();
-		Row row = rowBuilder.create();
-		t.addRow(row);
-		CompletableFuture<?> tableFuture;
-		if (field.getLookupTable() != null) {
-			tableFuture = getIndexDataAsync(t.getName(), t, true);
-		} else {
-			tableFuture = getDetailDataAsync(t.getName(), t, true);
-		}
-
-		return tableFuture;
-	}
-
 	@Override
 	public String getUserName() {
 		return username;
@@ -1049,13 +626,6 @@ public class DataService implements IDataService {
 	@Override
 	public void setLogger(Logger logger) {
 		this.logger = logger;
-	}
-
-	private void handleCASError(Throwable ex, String method, boolean showErrorMessage) {
-		log("CAS Error " + method + ":\n" + ex.getMessage());
-		if (showErrorMessage) {
-			showNoResposeServerError("msg.WFCNoResponseServer", ex);
-		}
 	}
 
 	@Override
@@ -1099,6 +669,74 @@ public class DataService implements IDataService {
 
 		} catch (IOException e) {
 			e.printStackTrace();
+		}
+	}
+
+	private void handleCASError(Throwable ex, String method, boolean showErrorMessage) {
+		log("CAS Error " + method + ":\n" + ex.getMessage());
+		if (showErrorMessage) {
+			showNoResposeServerError("msg.WFCNoResponseServer", ex);
+		}
+	}
+
+	public void postError(ErrorObject value) {
+		Dictionary<String, Object> data = new Hashtable<>(2);
+		data.put(EventConstants.EVENT_TOPIC, Constants.BROKER_SHOWERROR);
+		data.put(IEventBroker.DATA, value);
+		Event event = new Event(Constants.BROKER_SHOWERROR, data);
+		eventAdmin.postEvent(event);
+
+		log("CAS error:\n" + value.getErrorTable().getRows().get(0).getValue(0).getStringValue() + "\nUser: " + value.getUser() + "\nProcedure/View: "
+				+ value.getProcedureOrView());
+	}
+
+	public void postNotification(String message) {
+		Dictionary<String, Object> data = new Hashtable<>(2);
+		data.put(EventConstants.EVENT_TOPIC, Constants.BROKER_SHOWNOTIFICATION);
+		data.put(IEventBroker.DATA, message);
+		Event event = new Event(Constants.BROKER_SHOWNOTIFICATION, data);
+		eventAdmin.postEvent(event);
+	}
+
+	public void showNoResposeServerError(String message, Throwable th) {
+		// Fehlermeldung höchstens alle minTimeBetweenError Sekunden anzeigen
+		if ((System.currentTimeMillis() - timeOfLastConnectionErrorMessage) > minTimeBetweenError * 1000) {
+			Dictionary<String, Object> data = new Hashtable<>(2);
+			data.put(EventConstants.EVENT_TOPIC, Constants.BROKER_SHOWCONNECTIONERRORMESSAGE);
+			data.put(IEventBroker.DATA, new ErrorObject(message, username, th));
+			Event event = new Event(Constants.BROKER_SHOWCONNECTIONERRORMESSAGE, data);
+			eventAdmin.postEvent(event);
+			timeOfLastConnectionErrorMessage = System.currentTimeMillis();
+		}
+	}
+
+	private void logCache(String message) {
+		if (LOG_CACHE) {
+			System.out.println(message);
+		}
+	}
+
+	private void log(String body, Table table, boolean procedure) {
+		String sqlString = "";
+		try {
+			if (procedure) {
+				sqlString = SQLStringUtil.prepareProcedureString(table);
+			} else {
+				sqlString = SQLStringUtil.prepareViewString(table);
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		if (logSQLString) {
+			body = body + "\n" + sqlString;
+		}
+		log(body);
+	}
+
+	private void log(String body) {
+		if (logger != null) {
+			logger.info(body);
 		}
 	}
 }

--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/FileUtil.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/FileUtil.java
@@ -1,0 +1,62 @@
+package aero.minova.rcp.dataservice.internal;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import aero.minova.rcp.dataservice.HashService;
+
+public class FileUtil {
+
+	/**
+	 * Erstellt eine Datei falls sie existiert, wird sie geleert.
+	 *
+	 * @param path
+	 */
+	public static void createFile(String path) {
+		try {
+			File file = new File(path);
+			if (!file.exists()) {
+				file.createNewFile();
+			} else {
+				if (file.delete()) {
+					file.createNewFile();
+					return;
+				}
+				FileOutputStream writer = new FileOutputStream(path);
+				writer.write(("").getBytes());
+				writer.close();
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * Caller muss file.exists() aufgerufen haben
+	 *
+	 * @param file
+	 * @return
+	 */
+	public static CompletableFuture<String> getLocalHashForFile(File file) {
+		return CompletableFuture.supplyAsync(() -> {
+			try {
+				return HashService.hashFile(file);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			return "-1";
+		});
+	}
+
+	public static void ensureFoldersExist(File file) {
+		File folder = file.getParentFile();
+		if (!folder.exists()) {
+			if (!folder.mkdirs()) {
+				ensureFoldersExist(folder.getParentFile());
+			}
+		}
+	}
+
+}

--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/SQLStringUtil.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/SQLStringUtil.java
@@ -1,0 +1,254 @@
+package aero.minova.rcp.dataservice.internal;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import aero.minova.rcp.model.Column;
+import aero.minova.rcp.model.DataType;
+import aero.minova.rcp.model.FilterValue;
+import aero.minova.rcp.model.Row;
+import aero.minova.rcp.model.Table;
+import aero.minova.rcp.model.Value;
+
+/**
+ * Wandelt Tabellen in SQL-Strings um, die in der Datenbank verwendet werden können
+ * 
+ * @author janiak
+ */
+public class SQLStringUtil {
+
+	private static final String AND_FIELD_NAME = "&";
+
+	public static String prepareViewString(Table params) throws IllegalArgumentException {
+		return prepareViewString(params, false, 0, false);
+	}
+
+	/**
+	 * Diese Methode stammt ursprünglich aus "ch.minova.ncore.data.sql.SQLTools#prepareViewString". Bereitet einen View-String vor und berücksichtigt eine evtl.
+	 * angegebene Maximalanzahl Ergebnisse
+	 *
+	 * @param params
+	 *            Suchzeilen (z.B. Suchparameter), wobei auch ein Spezialfeld mit dem Namen 'AND' genutzt werden kann, um die Kriterien zu verknüpfen
+	 * @param autoLike
+	 *            wenn true, dann werden alle String-Parameter, die noch kein % haben, mit einem '%' am Ende versehen
+	 * @param maxRows
+	 *            maximale Anzahl Ergebnisse (Zeilen), die die Abfrage liefern soll, 0 für unbegrenzt
+	 * @param count
+	 *            Gibt an ob nur die Anzahl der Ergebniss (Zeilen), gezählt werden sollen.
+	 * @return Präparierter View-String, der ausgeführt werden kann
+	 * @throws IllegalArgumentException
+	 * @author wild
+	 */
+	private static String prepareViewString(Table params, boolean autoLike, int maxRows, boolean count) throws IllegalArgumentException {
+		final StringBuffer sb = new StringBuffer();
+		if (params.getName() == null || params.getName().trim().length() == 0) {
+			throw new IllegalArgumentException("msg.ViewNullName");
+		}
+
+		if (count) {
+			sb.append("select count(1) from ");
+		} else {
+			if (maxRows > 0) {
+				sb.append("select top ").append(maxRows).append(" ");
+			} else {
+				sb.append("select ");
+			}
+			List<Column> outputFormat = params.getColumns().stream()//
+					.filter(c -> !Objects.equals(c.getName(), AND_FIELD_NAME))//
+					.collect(Collectors.toList());
+			if (outputFormat.isEmpty()) {
+				sb.append("* from ");
+			} else {
+				sb.append(//
+						outputFormat.stream()//
+								.map(Column::getName)//
+								.collect(Collectors.joining(", ")));
+				sb.append(" from ");
+			}
+		}
+		sb.append(params.getName());
+		boolean whereClauseExists = false;
+		if (params.getColumns().size() > 0 && params.getRows().size() > 0) {
+			final String where = prepareWhereClause(params, autoLike);
+			sb.append(where);
+			if (!where.trim().equals("")) {
+				whereClauseExists = true;
+				sb.append(")");
+			}
+		}
+
+		return sb.toString();
+	}
+
+	/**
+	 * @param params
+	 *            Suchzeilen (z.B. Suchparameter), wobei auch ein Spezialfeld mit dem Namen 'AND' genutzt werden kann, um die Kriterien zu verknüpfen
+	 * @param autoLike
+	 *            wenn true, dann werden alle String-Parameter, die noch kein % haben, mit einem '%' am Ende versehen
+	 * @return die Where-Klausel für die angegebenen Parameter
+	 * @author wild
+	 */
+	private static String prepareWhereClause(Table params, boolean autoLike) {
+		final StringBuffer where = new StringBuffer();
+		final boolean hasAndClause;
+		// TODO Check size
+		List<Column> andFields = params.getColumns().stream()//
+				.filter(c -> Objects.equals(c.getName(), AND_FIELD_NAME))//
+				.collect(Collectors.toList());
+		final Column andField;
+		if (andFields.isEmpty()) {
+			hasAndClause = false;
+			andField = null;
+		} else {
+			hasAndClause = true;
+			andField = andFields.get(0);
+		}
+		int andFieldIndex = params.getColumns().indexOf(andField);
+		for (int rowI = 0; rowI < params.getRows().size(); rowI++) {
+			final Row r = params.getRows().get(rowI);
+			// TODO Nicht annehmen, dass die spezielle &-Spalte die letzte Spalte ist.
+			final boolean and;
+			if (hasAndClause) {
+				and = r.getValues().get(andFieldIndex).getBooleanValue();
+			} else {
+				and = false;
+			}
+
+			// Eine where Zeile aufbauen
+			final StringBuffer clause = new StringBuffer();
+			COLS: for (int colI = 0; colI < r.getValues().size(); ++colI) {
+				Value def = r.getValues().get(colI);
+				Column col = params.getColumns().get(colI);
+				if (AND_FIELD_NAME.equalsIgnoreCase(col.getName())) {
+					continue COLS;
+				}
+				if (r.getValues().get(colI) == null) {
+					continue COLS;
+				}
+
+				final Object valObj = r.getValues().get(colI).getValue();
+				if (valObj == null) {
+					continue;
+				}
+				String strValue = valObj.toString().trim();
+				String ruleValue = "";
+
+				Value v = r.getValues().get(colI);
+				if (v instanceof FilterValue) {
+					ruleValue = v.getValue().toString();
+					ruleValue = ruleToString(ruleValue);
+					if (((FilterValue) v).getFilterValue() != null) {
+						strValue = ((FilterValue) v).getFilterValue().getValue().toString();
+					} else {
+						strValue = "";
+					}
+				}
+
+				if (strValue != null && strValue.length() != 0) {
+					if (clause.length() > 0) {
+						clause.append(" and ");
+					}
+					clause.append(col.getName());
+
+					if (ruleValue != null && ruleValue.length() != 0) {
+						if (ruleValue.contains("in")) {
+							clause.append(" in(");
+
+							// für jeden der Komma-getrennten Werte muss ein Fragezeichen da sein
+							String valuesSeperatedByString = Stream.of(strValue.split(",")) //
+									.map(s -> "?").collect(Collectors.joining(", "));
+
+							clause.append(valuesSeperatedByString).append(")");
+						} else if (ruleValue.contains("between")) {
+							clause.append(" between ? and ?");
+						} else {
+							clause.append(" ").append(ruleValue).append(" '").append(strValue).append("'");
+						}
+					} else {
+						if (autoLike && valObj instanceof String && def.getType() == DataType.STRING && (!strValue.contains("%"))) {
+							strValue += "%";
+							Value newVal = new Value(strValue);
+							params.getRows().get(rowI).getValues().set(colI, newVal);
+						}
+						if (def.getType() == DataType.STRING && (strValue.contains("%") || strValue.contains("_"))) {
+							clause.append(" like");
+						} else {
+							clause.append(" =");
+						}
+						clause.append(" '").append(strValue).append("'");
+					}
+					// falls im Wert-Feld nichts steht, könnte immer noch die Regel is null oder is not null angefragt werden
+				} else if (ruleValue != null) {
+					if (ruleValue.contains("!null")) {
+						if (clause.length() > 0) {
+							clause.append(" and ");
+						}
+						clause.append(col.getName()).append(" is not null");
+					} else if (ruleValue.contains("null")) {
+						if (clause.length() > 0) {
+							clause.append(" and ");
+						}
+						clause.append(col.getName()).append(" is null");
+					}
+				}
+			}
+
+			// Wenn es etwas gab, dann fügen wir diese Zeile der kompletten WHERE-clause hinzu.
+			if (clause.length() > 0) {
+				if (where.length() == 0) {
+					where.append("\r\nwhere (");
+				} else {
+					where.append(and ? "\r\n  and " : "\r\n   or ");
+				}
+				where.append('(').append(clause.toString()).append(')');
+			}
+		}
+		return where.toString();
+	}
+
+	private static String ruleToString(String rule) {
+		if (rule.contains("null")) {
+
+		} else if (rule.contains("!~")) {
+			rule = "not like";
+
+		} else if (rule.contains("~")) {
+			rule = "like";
+		}
+		return rule;
+	}
+
+	/**
+	 * Bereitet einen Prozedur-String vor
+	 *
+	 * @param params
+	 *            SQL-Call-Parameter
+	 * @return SQL-Code
+	 * @throws IllegalArgumentException
+	 *             Fehler, wenn die Daten in params nicht richtig sind.
+	 */
+	public static String prepareProcedureString(Table params) throws IllegalArgumentException {
+		if (params.getName() == null || params.getName().trim().length() == 0) {
+			throw new IllegalArgumentException("msg.ProcedureNullName");
+		}
+		final int paramCount = params.getColumns().size();
+
+		final StringBuilder sb = new StringBuilder();
+		for (Row r : params.getRows()) {
+			sb.append("exec ").append(params.getName()).append(" ");
+			for (int i = 0; i < paramCount; i++) {
+				String val = "null";
+				if (r.getValue(i) != null && r.getValue(i).getValue() != null) {
+					val = r.getValue(i).getValue().toString();
+					val = "'" + val + "'";
+				}
+				sb.append(i == 0 ? val : "," + val);
+			}
+			sb.append("\n");
+		}
+		return sb.toString();
+	}
+
+}

--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/SQLStringUtil.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/SQLStringUtil.java
@@ -237,7 +237,7 @@ public class SQLStringUtil {
 			}
 			sb.append("\n");
 		}
-		return sb.toString();
+		return sb.toString().strip();
 	}
 
 }

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/LookupValueAccessor.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/LookupValueAccessor.java
@@ -135,7 +135,7 @@ public class LookupValueAccessor extends AbstractValueAccessor {
 
 	public void updatePossibleValues() {
 		LookupComposite up = ((LookupComposite) control);
-		CompletableFuture<List<LookupValue>> listLookup = dataService.listLookup((MLookupField) field, true, "%");
+		CompletableFuture<List<LookupValue>> listLookup = dataService.listLookup((MLookupField) field, true);
 		listLookup.thenAccept(l -> Display.getDefault().asyncExec(() -> {
 			try {
 				up.getContentProvider().setValuesOnly(l);

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/LookupField.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/fields/LookupField.java
@@ -116,7 +116,7 @@ public class LookupField {
 		ServiceReference<?> serviceReference = bundleContext.getServiceReference(IDataService.class.getName());
 		IDataService dataService = (IDataService) bundleContext.getService(serviceReference);
 
-		CompletableFuture<List<LookupValue>> listLookup = dataService.listLookup((MLookupField) field, false, "%");
+		CompletableFuture<List<LookupValue>> listLookup = dataService.listLookup((MLookupField) field, false);
 		listLookup.thenAccept(l -> Display.getDefault().asyncExec(() -> lookup.getContentProvider().setValues(l)));
 	}
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/LoadIndexHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/LoadIndexHandler.java
@@ -51,7 +51,7 @@ public class LoadIndexHandler {
 		((WFCSearchPart) findElements.get(0).getObject()).saveNattable();
 		((WFCSearchPart) findElements.get(0).getObject()).updateUserInput();
 		Table searchTable = (Table) findElements.get(0).getContext().get("NatTableDataSearchArea");
-		CompletableFuture<Table> tableFuture = dataService.getIndexDataAsync(searchTable.getName(), searchTable);
+		CompletableFuture<Table> tableFuture = dataService.getTableAsync(searchTable);
 
 		tableFuture.thenAccept(t -> {
 			loading = false;

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintDetailHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PrintDetailHandler.java
@@ -31,8 +31,8 @@ import org.xml.sax.SAXException;
 
 import aero.minova.rcp.constants.Constants;
 import aero.minova.rcp.dataservice.IDataService;
-import aero.minova.rcp.form.setup.xbs.Map.Entry;
 import aero.minova.rcp.form.setup.util.XBSUtil;
+import aero.minova.rcp.form.setup.xbs.Map.Entry;
 import aero.minova.rcp.form.setup.xbs.Node;
 import aero.minova.rcp.form.setup.xbs.Preferences;
 import aero.minova.rcp.model.DataType;
@@ -174,7 +174,7 @@ public class PrintDetailHandler {
 			table.addRow(row);
 
 			// XML-Dateil vom CAS laden
-			CompletableFuture<Path> tableFuture = dataService.getXMLAsync(table.getName(), table, rootElements.get(maskName));
+			CompletableFuture<Path> tableFuture = dataService.getXMLAsync(table, rootElements.get(maskName));
 			tableFuture.thenAccept(xmlPath -> sync.asyncExec(() -> {
 				try {
 					// Aus xml und xsl Datei PDF erstellen

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/LookupCASRequestUtil.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/LookupCASRequestUtil.java
@@ -70,7 +70,7 @@ public class LookupCASRequestUtil {
 					MField parameterControl = detail.getField(param);
 					tableBuilder.withColumn(param, parameterControl.getDataType());
 					if (parameterControl.getValue() != null) {
-					rowBuilder.withValue(parameterControl.getValue().getValue());
+						rowBuilder.withValue(parameterControl.getValue().getValue());
 					} else {
 						rowBuilder.withValue(null);
 					}
@@ -82,9 +82,9 @@ public class LookupCASRequestUtil {
 		t.addRow(row);
 		CompletableFuture<?> tableFuture;
 		if (field.getLookupTable() != null) {
-			tableFuture = dataService.getIndexDataAsync(t.getName(), t);
+			tableFuture = dataService.getTableAsync(t);
 		} else {
-			tableFuture = dataService.getDetailDataAsync(t.getName(), t);
+			tableFuture = dataService.callProcedureAsync(t);
 		}
 
 		return tableFuture;

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/LookupFieldFocusListener.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/LookupFieldFocusListener.java
@@ -58,7 +58,7 @@ public class LookupFieldFocusListener implements FocusListener {
 		row.addValue(new Value(tracNumber, DataType.STRING));
 		ticketTable.addRow(row);
 
-		CompletableFuture<SqlProcedureResult> tableFuture = dataService.getDetailDataAsync(ticketTable.getName(), ticketTable);
+		CompletableFuture<SqlProcedureResult> tableFuture = dataService.callProcedureAsync(ticketTable);
 		tableFuture.thenAccept(t -> sync.asyncExec(() -> {
 			if (t.getResultSet() != null) {
 				broker.post(Constants.RECEIVED_TICKET, t.getResultSet());

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/WFCDetailCASRequestsUtil.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/WFCDetailCASRequestsUtil.java
@@ -184,7 +184,7 @@ public class WFCDetailCASRequestsUtil {
 
 				// Hauptfelder
 				Table rowIndexTable = createReadTableFromForm(form, row);
-				CompletableFuture<SqlProcedureResult> tableFuture = dataService.getDetailDataAsync(rowIndexTable.getName(), rowIndexTable);
+				CompletableFuture<SqlProcedureResult> tableFuture = dataService.callProcedureAsync(rowIndexTable);
 				tableFuture.thenAccept(t -> sync.asyncExec(() -> {
 					if (t != null) {
 						selectedTable = t.getOutputParameters();
@@ -198,7 +198,7 @@ public class WFCDetailCASRequestsUtil {
 				selectedOptionPages.clear();
 				for (Form opForm : mDetail.getOptionPages()) {
 					Table opFormTable = createReadTableFromForm(opForm, row);
-					CompletableFuture<SqlProcedureResult> opFuture = dataService.getDetailDataAsync(opFormTable.getName(), opFormTable);
+					CompletableFuture<SqlProcedureResult> opFuture = dataService.callProcedureAsync(opFormTable);
 					opFuture.thenAccept(t -> sync.asyncExec(() -> {
 						selectedOptionPages.put(opForm.getDetail().getProcedureSuffix(), t.getOutputParameters());
 						updateSelectedEntry();
@@ -248,7 +248,7 @@ public class WFCDetailCASRequestsUtil {
 			Row gridRow = gridRowBuilder.create();
 			gridRequestTable.addRow(gridRow);
 
-			CompletableFuture<SqlProcedureResult> gridFuture = dataService.getGridDataAsync(gridRequestTable.getName(), gridRequestTable);
+			CompletableFuture<SqlProcedureResult> gridFuture = dataService.callProcedureAsync(gridRequestTable);
 			gridFuture.thenAccept(t -> sync.asyncExec(() -> {
 				if (t != null && t.getResultSet() != null) {
 					Table result = t.getResultSet();
@@ -380,7 +380,7 @@ public class WFCDetailCASRequestsUtil {
 		// Option Pages
 		for (Form opForm : mDetail.getOptionPages()) {
 			Table opFormTable = createInsertUpdateTableFromForm(opForm);
-			dataService.getDetailDataAsync(opFormTable.getName(), opFormTable);
+			dataService.callProcedureAsync(opFormTable);
 		}
 
 		// Grids
@@ -478,22 +478,22 @@ public class WFCDetailCASRequestsUtil {
 			}
 
 			if (!gridDeleteTable.getRows().isEmpty()) {
-				dataService.getGridDataAsync(gridDeleteTable.getName(), gridDeleteTable);
+				dataService.callProcedureAsync(gridDeleteTable);
 			}
 
 			if (!gridInsertTable.getRows().isEmpty()) {
-				dataService.getGridDataAsync(gridInsertTable.getName(), gridInsertTable);
+				dataService.callProcedureAsync(gridInsertTable);
 			}
 
 			if (!gridUpdateTable.getRows().isEmpty()) {
-				dataService.getGridDataAsync(gridUpdateTable.getName(), gridUpdateTable);
+				dataService.callProcedureAsync(gridUpdateTable);
 			}
 		}
 	}
 
 	private void sendSaveRequest(Table t) {
 		if (t.getRows() != null) {
-			CompletableFuture<SqlProcedureResult> tableFuture = dataService.getDetailDataAsync(t.getName(), t);
+			CompletableFuture<SqlProcedureResult> tableFuture = dataService.callProcedureAsync(t);
 
 			tableFuture.thenAccept(tr -> sync.asyncExec(() -> {
 				// Speichern wieder aktivieren
@@ -672,7 +672,7 @@ public class WFCDetailCASRequestsUtil {
 			// Hauptmaske
 			Table t = createDeleteTableFromForm(form);
 			if (t.getRows() != null) {
-				CompletableFuture<SqlProcedureResult> tableFuture = dataService.getDetailDataAsync(t.getName(), t);
+				CompletableFuture<SqlProcedureResult> tableFuture = dataService.callProcedureAsync(t);
 				tableFuture.thenAccept(ta -> sync.asyncExec(() -> {
 					if (ta != null) {
 						deleteEntry(ta);
@@ -741,7 +741,7 @@ public class WFCDetailCASRequestsUtil {
 		// Option Pages
 		for (Form opForm : mDetail.getOptionPages()) {
 			Table opFormTable = createDeleteTableFromForm(opForm);
-			dataService.getDetailDataAsync(opFormTable.getName(), opFormTable);
+			dataService.callProcedureAsync(opFormTable);
 		}
 
 		// In allen Grids alle Zeilen löschen
@@ -760,7 +760,7 @@ public class WFCDetailCASRequestsUtil {
 			}
 
 			if (!gridDeleteTable.getRows().isEmpty()) {
-				dataService.getGridDataAsync(gridDeleteTable.getName(), gridDeleteTable);
+				dataService.callProcedureAsync(gridDeleteTable);
 			}
 		}
 	}
@@ -776,7 +776,7 @@ public class WFCDetailCASRequestsUtil {
 		MPerspective activePerspective = model.getActivePerspective(partContext.get(MWindow.class));
 		if (activePerspective.equals(perspective) && table != null) {
 
-			CompletableFuture<SqlProcedureResult> tableFuture = dataService.getDetailDataAsync(table.getName(), table);
+			CompletableFuture<SqlProcedureResult> tableFuture = dataService.callProcedureAsync(table);
 
 			// Fehler abfangen
 			tableFuture.exceptionally(ex -> {
@@ -1060,7 +1060,7 @@ public class WFCDetailCASRequestsUtil {
 			r.addValue(f.getValue());
 		}
 		t.addRow(r);
-		dataService.getDetailDataAsync(t.getName(), t);
+		dataService.callProcedureAsync(t);
 	}
 
 	/**

--- a/bundles/aero.minova.rcp.widgets/src/aero/minova/rcp/widgets/LookupComposite.java
+++ b/bundles/aero.minova.rcp.widgets/src/aero/minova/rcp/widgets/LookupComposite.java
@@ -200,9 +200,8 @@ public class LookupComposite extends Composite {
 			popup.setVisible(false);
 			firstValue = null;
 			if (contentProvider.getValuesSize() == 0) {
-				MinovaNotifier.show(Display.getCurrent().getActiveShell(),
-						translationService.translate("@msg.NoLookupEntries", null),
-						translationService.translate("@Notification", null) );
+				MinovaNotifier.show(Display.getCurrent().getActiveShell(), translationService.translate("@msg.NoLookupEntries", null),
+						translationService.translate("@Notification", null));
 			}
 			return;
 		}
@@ -520,15 +519,14 @@ public class LookupComposite extends Composite {
 				ServiceReference<?> serviceReference = bundleContext.getServiceReference(IDataService.class.getName());
 				IDataService dataService = (IDataService) bundleContext.getService(serviceReference);
 
-				CompletableFuture<List<LookupValue>> listLookup = dataService.listLookup(field, false, "%");
+				CompletableFuture<List<LookupValue>> listLookup = dataService.listLookup(field, false);
 				setLastState();
 				listLookup.thenAccept(l -> {
 					Display.getDefault().asyncExec(() -> contentProvider.setValues(l));
 					gettingData = false;
 				});
 			} else {
-				MinovaNotifier.show(Display.getCurrent().getActiveShell(),
-						translationService.translate("@msg.ActiveRequest", null),
+				MinovaNotifier.show(Display.getCurrent().getActiveShell(), translationService.translate("@msg.ActiveRequest", null),
 						translationService.translate("@Notification", null));
 			}
 		} else {


### PR DESCRIPTION
Baut auf #932 auf

- Methodennamen aussagekräftiger gestaltet
  - getDetailDataAsync -> callProcedureAsync, Methode ruft allgemein mit
der übergebenen Tabelle eine Prozedur auf
  - getIndexDataAsync -> getTableAsync, Methode fragt die Tabelle aus
der Datenbank an, gefiltert nach der Suchtabelle
- Methodenaufrufe vereinfacht, nicht benötigte Variablen entfernt
- DataService aufgeräumt
  - Alle Variablen am Anfang der Klasse definiert
  - Methodenreihenfolge angepasst
  - Doppelten Code entfernt
  - Einige Methoden in neue FileUtil Klasse ausgelagert