### PR TITLE
Anwendungsspezifische Einstellungen

### DIFF
--- a/bundles/aero.minova.rcp.preferencewindow/META-INF/MANIFEST.MF
+++ b/bundles/aero.minova.rcp.preferencewindow/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Preferencewindow
-Bundle-SymbolicName: aero.minova.rcp.preferencewindow
+Bundle-SymbolicName: aero.minova.rcp.preferencewindow;singleton:=true
 Bundle-Version: 12.0.27.qualifier
 Automatic-Module-Name: aero.minova.rcp.preferencewindow
 Bundle-RequiredExecutionEnvironment: JavaSE-11
@@ -30,3 +30,4 @@ Import-Package: aero.minova.rcp.dataservice,
  org.apache.commons.io;version="2.6.0",
  org.eclipse.e4.ui.css.swt.theme,
  org.eclipse.jface.resource
+Bundle-ActivationPolicy: lazy

--- a/bundles/aero.minova.rcp.preferencewindow/build.properties
+++ b/bundles/aero.minova.rcp.preferencewindow/build.properties
@@ -2,4 +2,6 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               icons/
+               icons/,\
+               plugin.xml,\
+               schema/

--- a/bundles/aero.minova.rcp.preferencewindow/plugin.xml
+++ b/bundles/aero.minova.rcp.preferencewindow/plugin.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension-point id="minova.preferencepage" name="minova.preferencepage" schema="schema/minova.preferencepage.exsd"/>
+</plugin>

--- a/bundles/aero.minova.rcp.preferencewindow/schema/minova.preferencepage.exsd
+++ b/bundles/aero.minova.rcp.preferencewindow/schema/minova.preferencepage.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="aero.minova.rcp.preferencewindow" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="aero.minova.rcp.preferencewindow" id="minova.preferencepage" name="minova.preferencepage"/>
+      </appinfo>
+      <documentation>
+         Defines Minova preference pages to be displayed in the preference dialog window.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="page"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="page">
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn="aero.minova.rcp.preferencewindow.builder.PreferenceTabDescriptor:"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/bundles/aero.minova.rcp.preferencewindow/src/aero/minova/rcp/preferencewindow/builder/PreferenceWindowModel.java
+++ b/bundles/aero.minova.rcp.preferencewindow/src/aero/minova/rcp/preferencewindow/builder/PreferenceWindowModel.java
@@ -9,6 +9,13 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.services.translation.TranslationService;
 import org.eclipse.e4.ui.model.application.MApplication;
 
@@ -32,15 +39,16 @@ public class PreferenceWindowModel {
 		this.locale = locale;
 	}
 
-	public List<PreferenceTabDescriptor> createModel(TranslationService translationService) {
-
+	public List<PreferenceTabDescriptor> createModel(IEclipseContext context) {
+		TranslationService translationService = context.get(TranslationService.class);
+		IExtensionRegistry extensionRegistry = context.get(IExtensionRegistry.class);
 		Preferences preferences = (Preferences) mApplication.getTransientData().get(Constants.XBS_FILE_NAME);
 		xbsPreferences = XBSUtil.getMainMap(preferences);
 
 		List<PreferenceTabDescriptor> cprf = new ArrayList<>();
-
+				
 		cprf.add(buildAnwendungsTab(translationService));
-
+		
 		cprf.add(buildDarstellungsTab(translationService));
 
 		cprf.add(buildErweiterungTab(translationService));
@@ -49,10 +57,26 @@ public class PreferenceWindowModel {
 
 		cprf.add(buildConsoleTab(translationService));
 
-		cprf.add(buildSISTab(translationService));
+		IExtensionPoint point = extensionRegistry.getExtensionPoint("minova.preferencepage");
+		
+		for (IExtension extension : point.getExtensions()) {
+			// find the category first
+			for (IConfigurationElement element : extension.getConfigurationElements()) {
+				try {
+					PreferenceTabDescriptor createExecutableExtension = (PreferenceTabDescriptor) element.createExecutableExtension("class");
+					cprf.add(createExecutableExtension);
+				} catch (CoreException e1) {
+					e1.printStackTrace();
+				}
 
+			}
+		}
+	
+	
+		
 		return cprf;
 	}
+
 
 	private PreferenceTabDescriptor buildAnwendungsTab(TranslationService translationService) {
 		PreferenceTabDescriptor ptd = new PreferenceTabDescriptor("aero.minova.rcp.preferencewindow", "icons/Application.png", "applicationTab",
@@ -78,6 +102,7 @@ public class PreferenceWindowModel {
 				DisplayType.CHECK, true));
 		return ptd;
 	}
+
 
 	private PreferenceTabDescriptor buildDarstellungsTab(TranslationService translationService) {
 		PreferenceTabDescriptor ptd;
@@ -210,17 +235,5 @@ public class PreferenceWindowModel {
 		return ptd;
 	}
 
-	private PreferenceTabDescriptor buildSISTab(TranslationService translationService) {
-		PreferenceTabDescriptor ptd;
-		PreferenceSectionDescriptor psd;
-		ptd = new PreferenceTabDescriptor("aero.minova.rcp.preferencewindow", "icons/SIS.png", "sisTab",
-				translationService.translate("@Preferences.WorkingTime", null), 0.6);
-		psd = new PreferenceSectionDescriptor("user", translationService.translate("@Preferences.WorkingTime.UserPreselect", null), 0.1);
-		ptd.add(psd);
-		psd.add(new PreferenceDescriptor(ApplicationPreferences.USER_PRESELECT_DESCRIPTOR,
-				translationService.translate("@Preferences.WorkingTime.UserPreselectDescription", null), 0.1, DisplayType.STRING, "bauer"));
-
-		return ptd;
-	}
 
 }

--- a/bundles/aero.minova.rcp.preferencewindow/src/aero/minova/rcp/preferencewindow/pages/ApplicationPreferenceWindowHandler.java
+++ b/bundles/aero.minova.rcp.preferencewindow/src/aero/minova/rcp/preferencewindow/pages/ApplicationPreferenceWindowHandler.java
@@ -10,9 +10,11 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.core.commands.EHandlerService;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.services.nls.ILocaleChangeService;
@@ -98,7 +100,7 @@ public class ApplicationPreferenceWindowHandler {
 	IWorkbench workbench;
 
 	@Execute
-	public void execute(IThemeEngine themeEngine, IWorkbench workbench) {
+	public void execute(IThemeEngine themeEngine, IWorkbench workbench, IEclipseContext context) {
 		pwm = new PreferenceWindowModel(s);
 		ContextInjectionFactory.inject(pwm, application.getContext()); // In Context injected, damit TranslationService genutzt werden kann
 
@@ -113,7 +115,7 @@ public class ApplicationPreferenceWindowHandler {
 		String currentTheme = (String) InstancePreferenceAccessor.getValue(preferences, ApplicationPreferences.FONT_ICON_SIZE, DisplayType.COMBO, "M", s);
 		boolean curentSelectAllControls = (boolean) InstancePreferenceAccessor.getValue(preferences, ApplicationPreferences.SELECT_ALL_CONTROLS,
 				DisplayType.CHECK, true, s);
-		List<PreferenceTabDescriptor> preferenceTabs = pwm.createModel(translationService);
+		List<PreferenceTabDescriptor> preferenceTabs = pwm.createModel(context);
 		Map<String, Object> data = fillData(preferenceTabs);
 		PreferenceWindow window = PreferenceWindow.create(shell, data);
 


### PR DESCRIPTION
Extension point definiert mit ID minova.preferencepage
- schema mit dem man eine Klasse für den PreferencePage anlegen kann

Extension im Working Timehelper wird per separaten Commit geliefert

- plugin.xml kann man nun neue Page definieren
- IExtensionPointRegistry gibt Zugriff auf unsere Erweiterungen
- Model Auswertung liest diese Extension ein und erzeugt die Klassen
dann per DI

For #808