### PR TITLE
Trace Optionen erweitern

### DIFF
--- a/bundles/aero.minova.rcp.dataservice/.options
+++ b/bundles/aero.minova.rcp.dataservice/.options
@@ -7,5 +7,9 @@ aero.minova.rcp.dataservice/debug=false
 aero.minova.rcp.dataservice/debug/server=false
 # Turn on tracing for hashing and caching files
 aero.minova.rcp.dataservice/debug/cache=false
-
+# Turn on to use eclipse version of helper-plugins
 aero.minova.rcp.dataservice/debug/uselocalhelper=false
+# Turn on to prevent updates of files
+aero.minova.rcp.dataservice/debug/disablefileupdate=false
+# Turn on to log SQL equivalent of procedure calls
+aero.minova.rcp.dataservice/debug/logsqlstring=false


### PR DESCRIPTION
- Log des SQL-Strings für Prozeduranfragen kann an-/ausgestellt werden
- Das Update von files kann an-/ausgeschaltet werden. Wenn angestellt werden lokale Änderungen an z.B. Masken nicht überschrieben


closes #960