### PR TITLE
Kontakt-Felder als Lookups behandeln

### DIFF
--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataFormService.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataFormService.java
@@ -171,7 +171,7 @@ public class DataFormService implements IDataFormService {
 			} else if (f.getPercentage() != null) {
 				decimals = f.getPercentage().getDecimals();
 			}
-		} else if (f.getNumber() != null || f.getLookup() != null) {
+		} else if (f.getNumber() != null || f.getLookup() != null || f.getEditor() != null) {
 			type = DataType.INTEGER;
 		} else if (f.getMoney() != null) {
 			type = DataType.BIGDECIMAL;

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/ModelToViewModel.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/form/ModelToViewModel.java
@@ -18,6 +18,9 @@ public class ModelToViewModel {
 		if (field.getNumberColumnsSpanned() != null) {
 			f.setNumberColumnsSpanned(field.getNumberColumnsSpanned().intValue());
 		}
+		if (field.getEditor() != null) { // Contact Editor braucht immer 4 Spalten
+			f.setNumberColumnsSpanned(4);
+		}
 		if (field.getNumberRowsSpanned() != null) {
 			f.setNumberRowsSpanned(Integer.parseInt(field.getNumberRowsSpanned()));
 		}
@@ -47,6 +50,13 @@ public class ModelToViewModel {
 			for (TypeParam typeParam : field.getLookup().getParam()) {
 				f.addLookupParameter(typeParam.getFieldName());
 			}
+			return f;
+		}
+
+		if (field.getEditor() != null) {
+			MField f = new MLookupField();
+			f.setLookupTable("tContact");
+			f.setLookupDescription("LastName");
 			return f;
 		}
 
@@ -97,14 +107,7 @@ public class ModelToViewModel {
 			return f;
 		}
 
-		if (field.getEditor() != null) {
-			System.err.println("Field " + field.getName() + " is of Type Editor, which isn't implemented yet");
-		} else {
-			throw new RuntimeException("Typ of field " + field.getName() + " cannot  be determined");
-		}
-
-		// Filler Feld zurückgeben, damit restliche Maske gebaut werden kann
-		return new MTextField();
+		throw new RuntimeException("Typ of field " + field.getName() + " cannot  be determined");
 	}
 
 }


### PR DESCRIPTION
Mit dieser vorläufigen Lösung können alle Masken genutzt werden.

Die Kontaktfelder werden wie Lookups behandelt, als Beschreibung wird die Spalte `LastName` aus der Tabelle `tContact` genutzt.

<img width="739" alt="Bildschirmfoto 2021-10-29 um 14 28 12" src="https://user-images.githubusercontent.com/77741125/139434467-0d078efa-817d-41bf-bc85-942d056ef870.png">
<img width="710" alt="Bildschirmfoto 2021-10-29 um 14 28 22" src="https://user-images.githubusercontent.com/77741125/139434477-a625d923-79ff-49a1-8dad-cac8c233dbd7.png">

Damit hat Issue #718 vorerst geringe Priorität.
