### PR TITLE
Spies werden nun von 2021-12 gezogen

### DIFF
--- a/features/aero.minova.debug.feature/feature.xml
+++ b/features/aero.minova.debug.feature/feature.xml
@@ -17,20 +17,6 @@
    </license>
 
    <plugin
-         id="org.eclipse.e4.tools.model.spy"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.e4.tools.spy"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.emf.edit"
          download-size="0"
          install-size="0"
@@ -46,13 +32,6 @@
 
    <plugin
          id="org.eclipse.emf.common"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.e4.tools.emf.ui"
          download-size="0"
          install-size="0"
          version="0.0.0"
@@ -94,6 +73,34 @@
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.text"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.pde.spy.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.pde.spy.css"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.pde.spy.model"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="com.ibm.icu"
          download-size="0"
          install-size="0"
@@ -101,7 +108,7 @@
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.text"
+         id="org.eclipse.e4.tools.emf.ui"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/releng/target-definition/eclipse-2021-09.target
+++ b/releng/target-definition/eclipse-2021-09.target
@@ -31,14 +31,10 @@
 			<unit id="org.eclipse.nebula.widgets.nattable.extension.poi.source.feature.feature.group" version="1.5.1.201909181823"/>
 		</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="http://download.eclipse.org/e4/snapshots/org.eclipse.e4.tools/latest/"/>
-		<unit id="org.eclipse.e4.tools.bundle.spy.feature.feature.group" version="0.0.0"/>
-		<unit id="org.eclipse.e4.tools.context.spy.feature.feature.group" version="0.0.0"/>
-		<unit id="org.eclipse.e4.tools.css.spy.feature.feature.group" version="0.0.0"/>
-		<unit id="org.eclipse.e4.tools.event.spy.feature.feature.group" version="0.0.0"/>
-		<unit id="org.eclipse.e4.tools.model.spy.feature.feature.group" version="0.0.0"/>
-		<unit id="org.eclipse.e4.tools.preference.spy.feature.feature.group" version="0.0.0"/>
-		<unit id="org.eclipse.e4.tools.spies.feature.feature.group" version="0.0.0"/>
+		<repository location="http://download.eclipse.org/releases/2021-12"/>
+		<unit id="org.eclipse.pde.spy.css" version="0.0.0"/>
+		<unit id="org.eclipse.pde.spy.core" version="0.0.0"/>
+		<unit id="org.eclipse.pde.spy.model" version="0.0.0"/>
 	</location>
 	
 	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
Damit wird das Problem behoben, das das persistierte Modell nicht
geladen werden kann, wenn der Modellspy der Applikations hinzugefuegt
wird.