### PR TITLE
Error-Handling verbessern

### DIFF
--- a/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
+++ b/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
@@ -154,6 +154,7 @@ public class Constants {
 	public static final String AERO_MINOVA_RCP_RCP_COMMAND_LOADINDEX = "aero.minova.rcp.rcp.command.loadindex";
 	public static final String AERO_MINOVA_RCP_RCP_COMMAND_PRINTDETAIL = "aero.minova.rcp.rcp.command.printdetail";
 	public static final String AERO_MINOVA_RCP_RCP_COMMAND_SAVEDETAIL = "aero.minova.rcp.rcp.command.savedetail";
+	public static final String AERO_MINOVA_RCP_RCP_COMMAND_SELECTSEARCHPART = "aero.minova.rcp.rcp.command.selectsearchpart";
 
 	// XBS Einstellungen
 	public static final String XBS_SHOW_DELETE_DIALOG = "ShowDeleteDialog";

--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
@@ -577,14 +577,16 @@ public class DataService implements IDataService {
 		CompletableFuture<Table> tableFuture = getTableAsync(t, false);
 		try {
 			Table ta = tableFuture.get();
-			for (Row r : ta.getRows()) {
-				LookupValue lv = new LookupValue(//
-						r.getValue(0).getIntegerValue(), //
-						r.getValue(1).getStringValue(), //
-						r.getValue(2) == null ? null : r.getValue(2).getStringValue());
+			if (ta != null) {
+				for (Row r : ta.getRows()) {
+					LookupValue lv = new LookupValue(//
+							r.getValue(0).getIntegerValue(), //
+							r.getValue(1).getStringValue(), //
+							r.getValue(2) == null ? null : r.getValue(2).getStringValue());
 
-				map.put(lv.keyLong, lv);
-				list.add(lv);
+					map.put(lv.keyLong, lv);
+					list.add(lv);
+				}
 			}
 		} catch (Exception e) {
 			System.out.println("Error, using cache: " + tableName);
@@ -641,14 +643,19 @@ public class DataService implements IDataService {
 
 		CompletableFuture<SqlProcedureResult> tableFuture = callProcedureAsync(t, false);
 		try {
-			Table ta = tableFuture.get().getResultSet();
-			for (Row r : ta.getRows()) {
-				LookupValue lv = new LookupValue(//
-						r.getValue(0).getIntegerValue(), //
-						r.getValue(1).getStringValue(), //
-						r.getValue(2) == null ? null : r.getValue(2).getStringValue());
-				map.put(lv.keyLong, lv);
-				list.add(lv);
+			SqlProcedureResult res = tableFuture.get();
+			if (res != null) {
+				Table ta = res.getResultSet();
+				if (ta != null) {
+					for (Row r : ta.getRows()) {
+						LookupValue lv = new LookupValue(//
+								r.getValue(0).getIntegerValue(), //
+								r.getValue(1).getStringValue(), //
+								r.getValue(2) == null ? null : r.getValue(2).getStringValue());
+						map.put(lv.keyLong, lv);
+						list.add(lv);
+					}
+				}
 			}
 		} catch (Exception e) {
 			System.out.println("Error, using Cache: " + hashName);

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
@@ -372,6 +372,11 @@ public class PerspectiveControl {
 		} else {
 			ShowErrorDialogHandler.execute(shell, "Error", translate, et.getT());
 		}
+
+		// Wenn möglich Search-Part aktivieren, um wiederkehrende Fehler zu vermeiden
+		String commandID = Constants.AERO_MINOVA_RCP_RCP_COMMAND_SELECTSEARCHPART;
+		ParameterizedCommand cmd = commandService.createCommand(commandID, null);
+		handlerService.executeHandler(cmd);
 	}
 
 	@Inject

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/ShowErrorDialogHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/ShowErrorDialogHandler.java
@@ -12,12 +12,11 @@ import org.eclipse.swt.widgets.Shell;
 
 public class ShowErrorDialogHandler {
 	@Execute
-	public static void execute(final Shell shell, String title, String message, Throwable t) { // create exception on purpose to demonstrate ErrorDialog
+	public static void execute(final Shell shell, String title, String message, Throwable t) {
 		MultiStatus status;
 		status = createMultiStatus(t);
 		// show error dialog
 		ErrorDialog.openError(shell, title, message, status);
-
 	}
 
 	private static MultiStatus createMultiStatus(Throwable t) {

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/ShowErrorDialogHandler.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/ShowErrorDialogHandler.java
@@ -14,17 +14,16 @@ public class ShowErrorDialogHandler {
 	@Execute
 	public static void execute(final Shell shell, String title, String message, Throwable t) { // create exception on purpose to demonstrate ErrorDialog
 		MultiStatus status;
-		status = createMultiStatus(t.getLocalizedMessage(), t);
+		status = createMultiStatus(t);
 		// show error dialog
 		ErrorDialog.openError(shell, title, message, status);
 
 	}
 
-	private static MultiStatus createMultiStatus(String msg, Throwable t) {
+	private static MultiStatus createMultiStatus(Throwable t) {
 		MultiStatus ms;
 		List<Status> childStatuses = new ArrayList<>();
-		StackTraceElement[] stackTraces = Thread.currentThread().getStackTrace();
-		for (StackTraceElement stackTrace : stackTraces) {
+		for (StackTraceElement stackTrace : t.getStackTrace()) {
 			Status status = new Status(IStatus.ERROR, "aero.minova.rcp.rcp", stackTrace.toString());
 			childStatuses.add(status);
 		}

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/WFCDetailCASRequestsUtil.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/WFCDetailCASRequestsUtil.java
@@ -24,7 +24,6 @@ import org.eclipse.e4.core.services.translation.TranslationService;
 import org.eclipse.e4.ui.di.UIEventTopic;
 import org.eclipse.e4.ui.di.UISynchronize;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
-import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.services.IServiceConstants;
 import org.eclipse.e4.ui.workbench.UIEvents;
@@ -637,8 +636,9 @@ public class WFCDetailCASRequestsUtil {
 		MPerspective activePerspective = model.getActivePerspective(partContext.get(MWindow.class));
 		if (activePerspective.equals(perspective)) {
 			// Fokus auf den Search Part legen, damit Fehlermeldungen nicht mehrmals angezeigt werden
-			List<MPart> findElements = model.findElements(activePerspective, Constants.SEARCH_PART, MPart.class);
-			partService.activate(findElements.get(0));
+			String commandID = Constants.AERO_MINOVA_RCP_RCP_COMMAND_SELECTSEARCHPART;
+			ParameterizedCommand cmd = commandService.createCommand(commandID, null);
+			handlerService.executeHandler(cmd);
 
 			MessageDialog.openError(shell, ERROR, getTranslation(message));
 		}
@@ -666,8 +666,9 @@ public class WFCDetailCASRequestsUtil {
 			value += "\nProcedure/View: " + et.getProcedureOrView();
 
 			// Fokus auf den Search Part legen, damit Fehlermeldungen von Lookups nicht mehrmals angezeigt werden
-			List<MPart> findElements = model.findElements(activePerspective, Constants.SEARCH_PART, MPart.class);
-			partService.activate(findElements.get(0));
+			String commandID = Constants.AERO_MINOVA_RCP_RCP_COMMAND_SELECTSEARCHPART;
+			ParameterizedCommand cmd = commandService.createCommand(commandID, null);
+			handlerService.executeHandler(cmd);
 
 			if (et.getT() == null) {
 				MessageDialog.openError(shell, ERROR, value);


### PR DESCRIPTION
- Anzeigen der Stack-Trace der Exception, closes #923 
- Auch nach Verbindungs-Fehler versuchen, den Suchpart zu aktivieren. Damit sollte bei nicht erreichbarem Server keine Endlosschleife entstehen, wenn man in ein Lookup klickt. Trotzdem erscheint die Fehlermeldung teilweise mehr,als (siehe #1015)
 closes #924
- Nullpointer beim Anfragen/Auflösen von Lookups abfangen, sodass nur eine Fehlermeldung erscheint
