### PR TITLE
Nachrichten-Bereich im AboutDialog und Wizards einheitlich stylen

### DIFF
--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/AboutDialog.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/AboutDialog.java
@@ -11,6 +11,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -33,7 +34,7 @@ public class AboutDialog extends TitleAreaDialog {
 		resManager = new LocalResourceManager(JFaceResources.getResources(), parentShell);
 		lizenzFont = resManager.createFont(FontDescriptor.createFrom(new FontData("Arial", 12, SWT.NORMAL)));
 		infoFont = resManager.createFont(FontDescriptor.createFrom(new FontData("Arial", 14, SWT.NORMAL)));
-		
+		setTitleAreaColor(new RGB(236, 236, 236));
 	}
 
 	@Override

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardDialog.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardDialog.java
@@ -4,6 +4,7 @@ import org.eclipse.e4.core.services.translation.TranslationService;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.wizard.IWizard;
 import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
@@ -14,6 +15,7 @@ public class MinovaWizardDialog extends WizardDialog {
 
 	public MinovaWizardDialog(Shell parentShell, IWizard newWizard) {
 		super(parentShell, newWizard);
+		setTitleAreaColor(new RGB(236, 236, 236));
 	}
 
 	@Override


### PR DESCRIPTION

Kein weißer Streifen mehr im About-Dialog:
<img width="820" alt="Bildschirmfoto 2021-11-16 um 16 13 06" src="https://user-images.githubusercontent.com/77741125/142011741-855b7e0d-92e6-4975-89b6-ce6adb79efd7.png">

closes #1014