### PR TITLE
Fehler beim schließen und wieder öffnen einer Perspektive verhindern

### DIFF
--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/handlers/PerspectiveControl.java
@@ -304,13 +304,6 @@ public class PerspectiveControl {
 
 		openToolbarItems.remove(item.getData());
 		saveToolbarOrder();
-
-		Image icon = item.getImage();
-		if (icon != null) {
-			item.setImage(null);
-			icon.dispose();
-		}
-
 		item.dispose();
 	}
 


### PR DESCRIPTION
Das Image darf nicht über "sich selbst" disposed werden, wenn es mit einem ResourceManager erstellt wurde. Der Manager kümmert sich um das Disposen.