### PR TITLE
Verbesserungen für Wizards

### DIFF
--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/Table.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/Table.java
@@ -103,6 +103,10 @@ public class Table {
 		rows.addAll(newRows);
 	}
 
+	public void clearRows() {
+		rows.clear();
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;

--- a/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/helper/IMinovaWizard.java
+++ b/bundles/aero.minova.rcp.model/src/aero/minova/rcp/model/helper/IMinovaWizard.java
@@ -1,9 +1,12 @@
 package aero.minova.rcp.model.helper;
 
-import aero.minova.rcp.model.form.MDetail;
 import org.eclipse.jface.wizard.IWizard;
+
+import aero.minova.rcp.model.form.MDetail;
 
 public interface IMinovaWizard extends IWizard {
 
 	void setOriginalMDetail(MDetail originalMDetail);
+
+	MDetail getOriginalMDetail();
 }

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/CustomComparator.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/CustomComparator.java
@@ -1,0 +1,23 @@
+package aero.minova.rcp.rcp.util;
+
+import java.util.Comparator;
+
+public class CustomComparator implements Comparator<Object> {
+	@Override
+	public int compare(Object o1, Object o2) {
+		if (o1 == null) {
+			if (o2 == null) {
+				return 0;
+			} else {
+				return -1;
+			}
+		} else if (o2 == null) {
+			return 1;
+		} else if (o1 instanceof Comparable && o2 instanceof Comparable && o1.getClass().equals(o2.getClass())) { // Auch überprüfen, ob die Objekte die
+																													// gleiche Klasse haben
+			return ((Comparable) o1).compareTo(o2);
+		} else {
+			return o1.toString().compareTo(o2.toString());
+		}
+	}
+}

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/NattableSummaryUtil.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/NattableSummaryUtil.java
@@ -1,0 +1,171 @@
+package aero.minova.rcp.rcp.util;
+
+import org.eclipse.nebula.widgets.nattable.NatTable;
+import org.eclipse.nebula.widgets.nattable.config.AbstractRegistryConfiguration;
+import org.eclipse.nebula.widgets.nattable.config.IConfigRegistry;
+import org.eclipse.nebula.widgets.nattable.data.IDataProvider;
+import org.eclipse.nebula.widgets.nattable.data.ListDataProvider;
+import org.eclipse.nebula.widgets.nattable.style.DisplayMode;
+import org.eclipse.nebula.widgets.nattable.summaryrow.ISummaryProvider;
+import org.eclipse.nebula.widgets.nattable.summaryrow.SummaryRowConfigAttributes;
+import org.eclipse.nebula.widgets.nattable.summaryrow.SummaryRowLayer;
+import org.eclipse.nebula.widgets.nattable.summaryrow.SummationSummaryProvider;
+
+import aero.minova.rcp.constants.AggregateOption;
+import aero.minova.rcp.form.model.xsd.Form;
+import aero.minova.rcp.model.Row;
+import aero.minova.rcp.nattable.data.MinovaColumnPropertyAccessor;
+import ca.odell.glazedlists.SortedList;
+
+public class NattableSummaryUtil {
+
+	private NattableSummaryUtil() {}
+
+	public static void configureSummary(Form form, NatTable natTable, SortedList<Row> sortedList, MinovaColumnPropertyAccessor columnPropertyAccessor) {
+		final IDataProvider summaryDataProvider = new ListDataProvider<>(sortedList, columnPropertyAccessor);
+
+		// add summary configuration
+		natTable.addConfiguration(new AbstractRegistryConfiguration() {
+
+			@Override
+			public void configureRegistry(IConfigRegistry configRegistry) {
+				int i = 0;
+				for (aero.minova.rcp.form.model.xsd.Column column : form.getIndexView().getColumn()) {
+					ISummaryProvider summaryProvider = null;
+
+					if (column.getAggregate() != null) {
+						AggregateOption agg = AggregateOption.valueOf(column.getAggregate());
+						switch (agg) {
+						case AVERAGE:
+							summaryProvider = new AverageSummaryProvider(summaryDataProvider);
+							break;
+						case COUNT:
+							summaryProvider = new CountSummaryProvider(summaryDataProvider);
+							break;
+						case MAX:
+							summaryProvider = new MaxSummaryProvider(summaryDataProvider);
+							break;
+						case MIN:
+							summaryProvider = new MinSummaryProvider(summaryDataProvider);
+							break;
+						case SUM:
+							summaryProvider = new SummationSummaryProvider(summaryDataProvider, false);
+							break;
+						default:
+							break;
+						}
+					}
+
+					// Summe ("total" in .xml)
+					if (column.isTotal() != null && column.isTotal()) {
+						summaryProvider = new SummationSummaryProvider(summaryDataProvider, false);
+					}
+
+					if (summaryProvider != null) {
+						configRegistry.registerConfigAttribute(SummaryRowConfigAttributes.SUMMARY_PROVIDER, summaryProvider, DisplayMode.NORMAL,
+								SummaryRowLayer.DEFAULT_SUMMARY_COLUMN_CONFIG_LABEL_PREFIX + i);
+					}
+
+					i++;
+				}
+			}
+		});
+	}
+
+	static class CountSummaryProvider implements ISummaryProvider {
+
+		private IDataProvider dataProvider;
+
+		public CountSummaryProvider(IDataProvider dataProvider) {
+			this.dataProvider = dataProvider;
+		}
+
+		@Override
+		public Object summarize(int columnIndex) {
+			return this.dataProvider.getRowCount();
+		}
+	}
+
+	static class AverageSummaryProvider implements ISummaryProvider {
+
+		private IDataProvider dataProvider;
+
+		public AverageSummaryProvider(IDataProvider dataProvider) {
+			this.dataProvider = dataProvider;
+		}
+
+		@Override
+		public Object summarize(int columnIndex) {
+			int rowCount = this.dataProvider.getRowCount();
+			int valueRows = 0;
+			double total = 0;
+
+			for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+				Object dataValue = this.dataProvider.getDataValue(columnIndex, rowIndex);
+				// this check is necessary because of the GroupByObject
+				if (dataValue instanceof Number) {
+					valueRows++;
+					total += ((Number) dataValue).doubleValue();
+				}
+			}
+			if (valueRows == 0) {
+				return 0;
+			}
+			return total / valueRows;
+		}
+	}
+
+	static class MinSummaryProvider implements ISummaryProvider {
+
+		private IDataProvider dataProvider;
+
+		public MinSummaryProvider(IDataProvider dataProvider) {
+			this.dataProvider = dataProvider;
+		}
+
+		@Override
+		public Object summarize(int columnIndex) {
+			int rowCount = this.dataProvider.getRowCount();
+			double min = Double.MAX_VALUE;
+
+			for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+				Object dataValue = this.dataProvider.getDataValue(columnIndex, rowIndex);
+				// this check is necessary because of the GroupByObject
+				if (dataValue instanceof Number && ((Number) dataValue).doubleValue() < min) {
+					min = ((Number) dataValue).doubleValue();
+				}
+			}
+			if (min == Double.MAX_VALUE) {
+				return 0;
+			}
+			return min;
+		}
+	}
+
+	static class MaxSummaryProvider implements ISummaryProvider {
+
+		private IDataProvider dataProvider;
+
+		public MaxSummaryProvider(IDataProvider dataProvider) {
+			this.dataProvider = dataProvider;
+		}
+
+		@Override
+		public Object summarize(int columnIndex) {
+			int rowCount = this.dataProvider.getRowCount();
+			double max = Double.MIN_VALUE;
+
+			for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+				Object dataValue = this.dataProvider.getDataValue(columnIndex, rowIndex);
+				// this check is necessary because of the GroupByObject
+				if (dataValue instanceof Number && ((Number) dataValue).doubleValue() > max) {
+					max = ((Number) dataValue).doubleValue();
+				}
+			}
+			if (max == Double.MIN_VALUE) {
+				return 0;
+			}
+			return max;
+		}
+	}
+}

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizard.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizard.java
@@ -4,8 +4,6 @@ import javax.inject.Inject;
 
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
-import org.eclipse.jface.dialogs.DialogSettings;
-import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.Wizard;
 
@@ -20,7 +18,6 @@ import aero.minova.rcp.model.helper.IMinovaWizard;
  */
 public class MinovaWizard extends Wizard implements IMinovaWizard {
 	private IMinovaWizardFinishAction finishAction;
-	private Object opener;
 
 	@Inject
 	private IEclipseContext context;
@@ -29,26 +26,18 @@ public class MinovaWizard extends Wizard implements IMinovaWizard {
 
 	public MinovaWizard(String wizardName) {
 		this.setWindowTitle(wizardName);
-		this.init();
 	}
 
 	@Override
+	/**
+	 * Am Ende von Implementierungen super.addPages() aufrufen, damit Pages im Kontext sind!
+	 */
 	public void addPages() {
-		// wird von WizardDialog automatisch aufgerufen
-		// Beispiele:
-		// addPage(new PrintPage1());
-		// addPage(new PrintPage2());
 
-		// #23481: Deshalb müssen die abgeleiteten Klassen super.addPages() aufrufen
+		// Alle Pages in den Kontext injecten -> Am Ende von Implementierungen immer super.addPages() aufrufen
 		for (IWizardPage page : getPages()) {
 			ContextInjectionFactory.inject(page, context);
 		}
-	}
-
-	@Override
-	public void dispose() {
-		// pages werden von der Superklasse bereits bereinigt
-		super.dispose();
 	}
 
 	/**
@@ -56,24 +45,6 @@ public class MinovaWizard extends Wizard implements IMinovaWizard {
 	 */
 	public IMinovaWizardFinishAction getFinishAction() {
 		return finishAction;
-	}
-
-	/**
-	 * liefert das Objekt, das den Wizard geöffnet hat<br>
-	 * das kann das öffnende Fenster, oder auch ein Part oder DataSourceBundle sein
-	 *
-	 * @return
-	 */
-	public Object getOpener() {
-		return this.opener;
-	}
-
-	/**
-	 * kann verwendet werden, um Settings vorzubelegen und andere Werte zu initialisieren
-	 */
-	public void init() {
-		IDialogSettings dialogSettings = new DialogSettings(this.getClass().getSimpleName());
-		this.setDialogSettings(dialogSettings);
 	}
 
 	@Override
@@ -100,16 +71,6 @@ public class MinovaWizard extends Wizard implements IMinovaWizard {
 	 */
 	public void setFinishAction(IMinovaWizardFinishAction finishAction) {
 		this.finishAction = finishAction;
-	}
-
-	/**
-	 * setzt das Objekt, das den Wizard geöffnet hat<br>
-	 * das kann das öffnende Fenster, oder auch ein Part oder DataSourceBundle sein
-	 *
-	 * @param opener
-	 */
-	public void setOpener(Object opener) {
-		this.opener = opener;
 	}
 
 	@Override

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardDialog.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardDialog.java
@@ -30,10 +30,14 @@ public class MinovaWizardDialog extends WizardDialog {
 			cancelButton.setText(translationService.translate("@Abort", null));
 
 			Button backButton = getButton(IDialogConstants.BACK_ID);
-			backButton.setText("< " + translationService.translate("@Back", null));
+			if (backButton != null) {
+				backButton.setText("< " + translationService.translate("@Back", null));
+			}
 
 			Button nextButton = getButton(IDialogConstants.NEXT_ID);
-			nextButton.setText(translationService.translate("@Next", null) + " >");
+			if (nextButton != null) {
+				nextButton.setText(translationService.translate("@Next", null) + " >");
+			}
 		}
 	}
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardDialog.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardDialog.java
@@ -28,6 +28,12 @@ public class MinovaWizardDialog extends WizardDialog {
 
 			Button cancelButton = getButton(IDialogConstants.CANCEL_ID);
 			cancelButton.setText(translationService.translate("@Abort", null));
+
+			Button backButton = getButton(IDialogConstants.BACK_ID);
+			backButton.setText("< " + translationService.translate("@Back", null));
+
+			Button nextButton = getButton(IDialogConstants.NEXT_ID);
+			nextButton.setText(translationService.translate("@Next", null) + " >");
 		}
 	}
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardIndexUtil.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardIndexUtil.java
@@ -1,0 +1,347 @@
+package aero.minova.rcp.rcp.widgets;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.eclipse.e4.core.services.translation.TranslationService;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.nebula.widgets.nattable.NatTable;
+import org.eclipse.nebula.widgets.nattable.config.AbstractUiBindingConfiguration;
+import org.eclipse.nebula.widgets.nattable.config.ConfigRegistry;
+import org.eclipse.nebula.widgets.nattable.config.DefaultNatTableStyleConfiguration;
+import org.eclipse.nebula.widgets.nattable.copy.command.CopyDataCommandHandler;
+import org.eclipse.nebula.widgets.nattable.data.IColumnPropertyAccessor;
+import org.eclipse.nebula.widgets.nattable.data.IDataProvider;
+import org.eclipse.nebula.widgets.nattable.data.IRowDataProvider;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.GlazedListsEventLayer;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.GlazedListsSortModel;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.groupBy.GroupByDataLayer;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.groupBy.GroupByHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.groupBy.GroupByHeaderMenuConfiguration;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.groupBy.GroupByModel;
+import org.eclipse.nebula.widgets.nattable.extension.glazedlists.groupBy.command.UngroupByColumnIndexCommand;
+import org.eclipse.nebula.widgets.nattable.grid.GridRegion;
+import org.eclipse.nebula.widgets.nattable.grid.data.DefaultColumnHeaderDataProvider;
+import org.eclipse.nebula.widgets.nattable.grid.data.DefaultCornerDataProvider;
+import org.eclipse.nebula.widgets.nattable.grid.data.DefaultRowHeaderDataProvider;
+import org.eclipse.nebula.widgets.nattable.grid.data.FixedSummaryRowHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.ColumnHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.CornerLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.DefaultColumnHeaderDataLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.DefaultRowHeaderDataLayer;
+import org.eclipse.nebula.widgets.nattable.grid.layer.GridLayer;
+import org.eclipse.nebula.widgets.nattable.hideshow.ColumnHideShowLayer;
+import org.eclipse.nebula.widgets.nattable.layer.AbstractLayerTransform;
+import org.eclipse.nebula.widgets.nattable.layer.CompositeLayer;
+import org.eclipse.nebula.widgets.nattable.layer.DataLayer;
+import org.eclipse.nebula.widgets.nattable.layer.ILayer;
+import org.eclipse.nebula.widgets.nattable.layer.LabelStack;
+import org.eclipse.nebula.widgets.nattable.layer.cell.ColumnLabelAccumulator;
+import org.eclipse.nebula.widgets.nattable.layer.cell.ColumnOverrideLabelAccumulator;
+import org.eclipse.nebula.widgets.nattable.painter.layer.GridLineCellLayerPainter;
+import org.eclipse.nebula.widgets.nattable.reorder.ColumnReorderLayer;
+import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer;
+import org.eclipse.nebula.widgets.nattable.selection.config.DefaultRowSelectionLayerConfiguration;
+import org.eclipse.nebula.widgets.nattable.sort.SortConfigAttributes;
+import org.eclipse.nebula.widgets.nattable.sort.SortHeaderLayer;
+import org.eclipse.nebula.widgets.nattable.sort.action.SortColumnAction;
+import org.eclipse.nebula.widgets.nattable.sort.config.SingleClickSortConfiguration;
+import org.eclipse.nebula.widgets.nattable.sort.event.ColumnHeaderClickEventMatcher;
+import org.eclipse.nebula.widgets.nattable.style.DisplayMode;
+import org.eclipse.nebula.widgets.nattable.summaryrow.FixedSummaryRowLayer;
+import org.eclipse.nebula.widgets.nattable.tree.TreeLayer;
+import org.eclipse.nebula.widgets.nattable.tree.config.TreeLayerExpandCollapseKeyBindings;
+import org.eclipse.nebula.widgets.nattable.ui.binding.UiBindingRegistry;
+import org.eclipse.nebula.widgets.nattable.ui.matcher.MouseEventMatcher;
+import org.eclipse.nebula.widgets.nattable.viewport.ViewportLayer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.widgets.Composite;
+
+import aero.minova.rcp.constants.Constants;
+import aero.minova.rcp.dataservice.IDataFormService;
+import aero.minova.rcp.dataservice.IDataService;
+import aero.minova.rcp.form.model.xsd.Form;
+import aero.minova.rcp.model.Row;
+import aero.minova.rcp.model.Table;
+import aero.minova.rcp.nattable.data.MinovaColumnPropertyAccessor;
+import aero.minova.rcp.rcp.nattable.MinovaIndexConfiguration;
+import aero.minova.rcp.rcp.util.CustomComparator;
+import aero.minova.rcp.rcp.util.NattableSummaryUtil;
+import ca.odell.glazedlists.EventList;
+import ca.odell.glazedlists.GlazedLists;
+import ca.odell.glazedlists.SortedList;
+import ca.odell.glazedlists.TransformedList;
+
+public class MinovaWizardIndexUtil {
+
+	@Inject
+	TranslationService translationService;
+
+	@Inject
+	IDataService dataService;
+
+	@Inject
+	protected IDataFormService dataFormService;
+
+	private String formName;
+
+	private Table table;
+
+	private BodyLayerStack<Row> bodyLayerStack;
+
+	/**
+	 * Kann genutzt werden, um in einer Wizard-Page eine Tabelle aufzubauen. <br>
+	 * Anwendungsbeispiel: <br>
+	 * 
+	 * <pre>
+	 * MinovaWizardIndexUtil indexUtil = new MinovaWizardIndexUtil("AutoInvoiceContracts.xml");
+	 * ContextInjectionFactory.inject(indexUtil, context); // Wichig, damit Übersetzungen, ... funktionieren
+	 * NatTable natTable = indexUtil.createNattable(container);
+	 * </pre>
+	 * 
+	 * @param formName
+	 */
+	public MinovaWizardIndexUtil(String formName) {
+		this.formName = formName;
+	}
+
+	public NatTable createNattable(Composite parent) {
+
+		NatTable natTable;
+
+		Form form = dataFormService.getForm(formName);
+
+		table = dataFormService.getTableFromFormIndex(form);
+
+		// Datenmodel für die Eingaben
+		ConfigRegistry configRegistry = new ConfigRegistry();
+		MinovaColumnPropertyAccessor columnPropertyAccessor = new MinovaColumnPropertyAccessor(getTable(), form);
+		columnPropertyAccessor.initPropertyNames(translationService);
+
+		// create the body stack
+		bodyLayerStack = new BodyLayerStack<>(getTable().getRows(), columnPropertyAccessor, configRegistry);
+		bodyLayerStack.getBodyDataLayer().setConfigLabelAccumulator(new ColumnLabelAccumulator());
+
+		// build the column header layer
+		IDataProvider columnHeaderDataProvider = new DefaultColumnHeaderDataProvider(columnPropertyAccessor.getPropertyNames(),
+				columnPropertyAccessor.getTableHeadersMap());
+		DefaultColumnHeaderDataLayer columnHeaderDataLayer = new DefaultColumnHeaderDataLayer(columnHeaderDataProvider);
+		ColumnHeaderLayer columnHeaderLayer = new ColumnHeaderLayer(columnHeaderDataLayer, bodyLayerStack, bodyLayerStack.getSelectionLayer());
+
+		SortHeaderLayer<Row> sortHeaderLayer = new SortHeaderLayer<>(columnHeaderLayer,
+				new GlazedListsSortModel<>(bodyLayerStack.getSortedList(), columnPropertyAccessor, configRegistry, columnHeaderDataLayer), false);
+		// Eigenen Sort-Comparator auf alle Spalten registrieren (Verhindert Fehler bei Zeilen, die keinen von- oder bis-Wert haben)
+		ColumnOverrideLabelAccumulator labelAccumulator = new ColumnOverrideLabelAccumulator(columnHeaderDataLayer);
+		columnHeaderDataLayer.setConfigLabelAccumulator(labelAccumulator);
+		for (int i = 0; i < columnHeaderDataLayer.getColumnCount(); i++) {
+			labelAccumulator.registerColumnOverrides(i, Constants.COMPARATOR_LABEL);
+		}
+		configRegistry.registerConfigAttribute(SortConfigAttributes.SORT_COMPARATOR, new CustomComparator(), DisplayMode.NORMAL, Constants.COMPARATOR_LABEL);
+
+		// connect sortModel to GroupByDataLayer to support sorting by group by summary values
+		bodyLayerStack.getBodyDataLayer().initializeTreeComparator(sortHeaderLayer.getSortModel(), bodyLayerStack.getTreeLayer(), true);
+
+		// build the Summary Row
+		FixedSummaryRowLayer summaryRowLayer = new FixedSummaryRowLayer(bodyLayerStack.getGlazedListsEventLayer(), bodyLayerStack.getViewportLayer(),
+				configRegistry, false);
+		summaryRowLayer.setHorizontalCompositeDependency(false);
+		CompositeLayer summaryComposite = new CompositeLayer(1, 2);
+		summaryComposite.setChildLayer("SUMMARY", summaryRowLayer, 0, 0);
+		summaryComposite.setChildLayer(GridRegion.BODY, bodyLayerStack.getViewportLayer(), 0, 1);
+
+		// build the row header layer
+		IDataProvider rowHeaderDataProvider = new DefaultRowHeaderDataProvider(bodyLayerStack.getBodyDataProvider());
+		DataLayer rowHeaderDataLayer = new DefaultRowHeaderDataLayer(rowHeaderDataProvider);
+		// Special RowHeader for summary
+		ILayer rowHeaderLayer = new FixedSummaryRowHeaderLayer(rowHeaderDataLayer, summaryComposite, bodyLayerStack.getSelectionLayer());
+		((FixedSummaryRowHeaderLayer) rowHeaderLayer).setSummaryRowLabel("");
+
+		// build the corner layer
+		IDataProvider cornerDataProvider = new DefaultCornerDataProvider(columnHeaderDataProvider, rowHeaderDataProvider);
+		DataLayer cornerDataLayer = new DataLayer(cornerDataProvider);
+		ILayer cornerLayer = new CornerLayer(cornerDataLayer, rowHeaderLayer, columnHeaderLayer);
+
+		// build the grid layer
+		GridLayer gridLayer = new GridLayer(summaryComposite, sortHeaderLayer, rowHeaderLayer, cornerLayer);
+
+		// ensure the body data layer uses a layer painter with correct configured clipping
+		bodyLayerStack.getBodyDataLayer().setLayerPainter(new GridLineCellLayerPainter(false, true));
+
+		// set the group by header on top of the grid
+		CompositeLayer compositeGridLayer = new CompositeLayer(1, 2);
+		GroupByHeaderLayer groupByHeaderLayer = new GroupByHeaderLayer(bodyLayerStack.getGroupByModel(), gridLayer, columnHeaderDataProvider,
+				columnHeaderLayer);
+		compositeGridLayer.setChildLayer(GroupByHeaderLayer.GROUP_BY_REGION, groupByHeaderLayer, 0, 0);
+		compositeGridLayer.setChildLayer("Grid", gridLayer, 0, 1);
+
+		SelectionLayer selectionLayer = bodyLayerStack.getSelectionLayer();
+		selectionLayer.addConfiguration(new DefaultRowSelectionLayerConfiguration());
+
+		CopyDataCommandHandler copyHandler = new CopyDataCommandHandler(selectionLayer, columnHeaderDataLayer, rowHeaderDataLayer);
+		copyHandler.setCopyFormattedText(true);
+		gridLayer.registerCommandHandler(copyHandler);
+
+		natTable = new NatTable(parent, compositeGridLayer, false);
+		// as the autoconfiguration of the NatTable is turned off, we have to add the DefaultNatTableStyleConfiguration and the ConfigRegistry manually
+		natTable.setConfigRegistry(configRegistry);
+		natTable.addConfiguration(new DefaultNatTableStyleConfiguration());
+
+		natTable.addConfiguration(new SingleClickSortConfiguration() {
+			@Override
+			public void configureUiBindings(final UiBindingRegistry uiBindingRegistry) {
+				// normal
+				uiBindingRegistry.registerFirstSingleClickBinding(new ColumnHeaderClickEventMatcher(SWT.NONE, 1), new SortColumnAction(false));
+
+				// multi
+				int keyMask = SWT.MOD3;
+				// für Linux andere Tastenkombi definieren
+				if (System.getProperty("os.name").startsWith("Linux")) {
+					keyMask |= SWT.MOD2;
+				}
+				uiBindingRegistry.registerSingleClickBinding(MouseEventMatcher.columnHeaderLeftClick(keyMask), new SortColumnAction(true));
+			}
+		});
+
+		MinovaIndexConfiguration mic = new MinovaIndexConfiguration(getTable().getColumns(), form);
+		natTable.addConfiguration(mic);
+		bodyLayerStack.columnHideShowLayer.hideColumnPositions(mic.getHiddenColumns());
+
+		// add group by configuration
+		natTable.addConfiguration(new GroupByHeaderMenuConfiguration(natTable, groupByHeaderLayer));
+		// adds the key bindings that allow space bar to be pressed to expand/collapse tree nodes
+		natTable.addConfiguration(new TreeLayerExpandCollapseKeyBindings(bodyLayerStack.getTreeLayer(), bodyLayerStack.getSelectionLayer()));
+
+		// Bei Doppelklick auf ein gruppiertes Element diese Gruppierung entfernen
+		natTable.addConfiguration(new AbstractUiBindingConfiguration() {
+			@Override
+			public void configureUiBindings(UiBindingRegistry uiBindingRegistry) {
+				uiBindingRegistry.registerDoubleClickBinding(new MouseEventMatcher(SWT.NONE, GroupByHeaderLayer.GROUP_BY_REGION) {
+					@Override
+					public boolean matches(NatTable natTable, MouseEvent event, LabelStack regionLabels) {
+						if (super.matches(natTable, event, regionLabels)) {
+							return groupByHeaderLayer.getGroupByColumnIndexAtXY(event.x, event.y) >= 0;
+						}
+						return false;
+					}
+				}, (natTable1, event) -> {
+					int groupByColumnIndex = groupByHeaderLayer.getGroupByColumnIndexAtXY(event.x, event.y);
+					natTable1.doCommand(new UngroupByColumnIndexCommand(groupByColumnIndex));
+				});
+			}
+		});
+
+		NattableSummaryUtil.configureSummary(form, natTable, bodyLayerStack.getSortedList(), columnPropertyAccessor);
+
+		natTable.configure();
+		natTable.setLayoutData(GridDataFactory.fillDefaults().grab(true, true).create());
+
+		return natTable;
+
+	}
+
+	public Table getTable() {
+		return table;
+	}
+
+	public SortedList<Row> getSortedList() {
+		return bodyLayerStack.getSortedList();
+	}
+
+	public class BodyLayerStack<T> extends AbstractLayerTransform {
+
+		private final SortedList<T> sortedList;
+
+		private final IRowDataProvider<Row> bodyDataProvider;
+
+		private final SelectionLayer selectionLayer;
+
+		private final GroupByModel groupByModel = new GroupByModel();
+
+		private EventList<T> eventList;
+
+		private GroupByDataLayer<T> bodyDataLayer;
+
+		private TreeLayer treeLayer;
+
+		private GlazedListsEventLayer glazedListsEventLayer;
+
+		private ViewportLayer viewportLayer;
+
+		private ColumnReorderLayer columnReorderLayer;
+
+		private ColumnHideShowLayer columnHideShowLayer;
+
+		public BodyLayerStack(List<T> values, IColumnPropertyAccessor<T> columnPropertyAccessor, ConfigRegistry configRegistry) {
+			eventList = GlazedLists.eventList(values);
+			TransformedList<T, T> rowObjectsGlazedList = GlazedLists.threadSafeList(eventList);
+
+			// use the SortedList constructor with 'null' for the Comparator because the Comparator will be set by configuration
+			this.sortedList = new SortedList<>(rowObjectsGlazedList, null);
+
+			bodyDataLayer = new GroupByDataLayer<>(getGroupByModel(), this.sortedList, columnPropertyAccessor, configRegistry);
+
+			// get the IDataProvider that was created by the GroupByDataLayer
+			this.bodyDataProvider = (IRowDataProvider<Row>) bodyDataLayer.getDataProvider();
+
+			// layer for event handling of GlazedLists and PropertyChanges
+			glazedListsEventLayer = new GlazedListsEventLayer<>(bodyDataLayer, this.sortedList);
+
+			columnReorderLayer = new ColumnReorderLayer(glazedListsEventLayer);
+			columnHideShowLayer = new ColumnHideShowLayer(columnReorderLayer);
+			this.selectionLayer = new SelectionLayer(getColumnHideShowLayer());
+
+			treeLayer = new TreeLayer(this.selectionLayer, bodyDataLayer.getTreeRowModel());
+
+			viewportLayer = new ViewportLayer(treeLayer);
+
+			setUnderlyingLayer(viewportLayer);
+		}
+
+		public GlazedListsEventLayer getGlazedListsEventLayer() {
+			return glazedListsEventLayer;
+		}
+
+		public SelectionLayer getSelectionLayer() {
+			return this.selectionLayer;
+		}
+
+		public ViewportLayer getViewportLayer() {
+			return this.viewportLayer;
+		}
+
+		public SortedList<T> getSortedList() {
+			return this.sortedList;
+		}
+
+		public GroupByDataLayer<T> getBodyDataLayer() {
+			return this.bodyDataLayer;
+		}
+
+		public TreeLayer getTreeLayer() {
+			return this.treeLayer;
+		}
+
+		public IRowDataProvider<Row> getBodyDataProvider() {
+			return this.bodyDataProvider;
+		}
+
+		public GroupByModel getGroupByModel() {
+			return this.groupByModel;
+		}
+
+		public EventList<T> getList() {
+			return eventList;
+		}
+
+		public ColumnReorderLayer getColumnReorderLayer() {
+			return columnReorderLayer;
+		}
+
+		public ColumnHideShowLayer getColumnHideShowLayer() {
+			return columnHideShowLayer;
+		}
+	}
+
+}

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardPage.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardPage.java
@@ -1,0 +1,63 @@
+package aero.minova.rcp.rcp.widgets;
+
+import org.eclipse.jface.dialogs.IPageChangedListener;
+import org.eclipse.jface.dialogs.PageChangedEvent;
+import org.eclipse.jface.wizard.IWizardContainer;
+import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+
+public class MinovaWizardPage extends WizardPage {
+	private static class MinovaWizardPageChangedListener implements IPageChangedListener {
+		@Override
+		public void pageChanged(PageChangedEvent event) {
+			Object selectedPage = event.getSelectedPage();
+			if (selectedPage instanceof MinovaWizardPage) {
+				((MinovaWizardPage) selectedPage).onSelect();
+			}
+		}
+	}
+
+	private static final MinovaWizardPageChangedListener mwpcl = new MinovaWizardPageChangedListener();
+
+	public MinovaWizardPage(String pageName, String pageTitle, String pageDescription) {
+		super(pageName);
+		setTitle(pageTitle);
+		setDescription(pageDescription);
+	}
+
+	@Override
+	/**
+	 * Von Unterklassen überschrieben. Wichtig: setControl() und init() Aufruf am Ende!
+	 */
+	public void createControl(Composite parent) {
+		Composite container = new Composite(parent, SWT.NULL);
+		setControl(container);
+		init();
+	}
+
+	/**
+	 * kann nachdem der Container (WizardDialog) gesetzt wurde noch etwas initialisieren (z.B. Listener). <br>
+	 * Ohne wird die onSelect() Methode nicht aufgerufen!
+	 */
+	protected void init() {
+		IWizardContainer wizardContainer = this.getContainer();
+		if (wizardContainer instanceof WizardDialog) {
+			// und was anderes kommt eigentlich nicht vor...
+
+			// füge den oben definierten Listener hinzu, der onSelect aufruft
+			// intern wird bereits geprüft, ob der Listener doppelt ist
+			((WizardDialog) wizardContainer).addPageChangedListener(mwpcl);
+
+			// von abgeleiteten Klassen können auch mehr Listener hinzugefügt werden
+		}
+	}
+
+	/**
+	 * wird aufgerufen, wenn die Seite ausgewählt wird
+	 */
+	protected void onSelect() {
+		// Von Unterklassen implementiert wenn bei Auswahl etwas geschehen soll
+	}
+}

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardPage.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardPage.java
@@ -1,5 +1,12 @@
 package aero.minova.rcp.rcp.widgets;
 
+import java.util.Locale;
+
+import javax.inject.Inject;
+
+import org.eclipse.e4.core.di.extensions.Preference;
+import org.eclipse.e4.core.services.translation.TranslationService;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.jface.dialogs.IPageChangedListener;
 import org.eclipse.jface.dialogs.PageChangedEvent;
 import org.eclipse.jface.wizard.IWizardContainer;
@@ -8,23 +15,59 @@ import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 
-public class MinovaWizardPage extends WizardPage {
-	private static class MinovaWizardPageChangedListener implements IPageChangedListener {
-		@Override
-		public void pageChanged(PageChangedEvent event) {
-			Object selectedPage = event.getSelectedPage();
-			if (selectedPage instanceof MinovaWizardPage) {
-				((MinovaWizardPage) selectedPage).onSelect();
-			}
-		}
-	}
+import aero.minova.rcp.model.DataType;
+import aero.minova.rcp.model.DateTimeType;
+import aero.minova.rcp.model.event.ValueChangeEvent;
+import aero.minova.rcp.model.event.ValueChangeListener;
+import aero.minova.rcp.model.form.MBooleanField;
+import aero.minova.rcp.model.form.MDateTimeField;
+import aero.minova.rcp.model.form.MDetail;
+import aero.minova.rcp.model.form.MField;
+import aero.minova.rcp.model.form.MLookupField;
+import aero.minova.rcp.model.form.MNumberField;
+import aero.minova.rcp.model.form.MSection;
+import aero.minova.rcp.model.form.MShortDateField;
+import aero.minova.rcp.model.form.MShortTimeField;
+import aero.minova.rcp.model.form.MTextField;
+import aero.minova.rcp.preferences.ApplicationPreferences;
+import aero.minova.rcp.preferencewindow.control.CustomLocale;
+import aero.minova.rcp.rcp.accessor.DetailAccessor;
+import aero.minova.rcp.rcp.fields.BooleanField;
+import aero.minova.rcp.rcp.fields.DateTimeField;
+import aero.minova.rcp.rcp.fields.NumberField;
+import aero.minova.rcp.rcp.fields.ShortDateField;
+import aero.minova.rcp.rcp.fields.ShortTimeField;
+import aero.minova.rcp.rcp.fields.TextField;
+
+public class MinovaWizardPage extends WizardPage implements ValueChangeListener {
+
+	@Inject
+	@Preference(nodePath = ApplicationPreferences.PREFERENCES_NODE, value = ApplicationPreferences.TIMEZONE)
+	String timezone;
+
+	@Inject
+	private TranslationService translationService;
+
+	@Inject
+	private MPerspective mPerspective;
+
+	Locale locale = CustomLocale.getLocale();
+
+	// Leider für die Required Prüfung Notwendig
+	MSection mSection;
 
 	private static final MinovaWizardPageChangedListener mwpcl = new MinovaWizardPageChangedListener();
+	protected MDetail mDetail;
 
 	public MinovaWizardPage(String pageName, String pageTitle, String pageDescription) {
 		super(pageName);
 		setTitle(pageTitle);
 		setDescription(pageDescription);
+
+		mDetail = new MDetail();
+		mDetail.setDetailAccessor(new DetailAccessor(mDetail));
+
+		mSection = new MSection(false, "", mDetail, "", "");
 	}
 
 	@Override
@@ -59,5 +102,108 @@ public class MinovaWizardPage extends WizardPage {
 	 */
 	protected void onSelect() {
 		// Von Unterklassen implementiert wenn bei Auswahl etwas geschehen soll
+	}
+
+	/**
+	 * Erstellt ein MField inkl dem UI. <br>
+	 * Achtung: Für Lookups methode createMLookupField verwenden!
+	 * 
+	 * @param composite
+	 * @param dataType
+	 * @param dateTimeType
+	 * @param label
+	 * @param row
+	 * @param column
+	 * @param required
+	 * @return
+	 */
+	protected MField createMField(Composite composite, DataType dataType, DateTimeType dateTimeType, String label, int row, int column, boolean required) {
+
+		MField mField = null;
+		switch (dataType) {
+		case BIGDECIMAL:
+		case DOUBLE:
+			mField = new MNumberField(2);
+			initField(label, required, mField);
+			NumberField.create(composite, (MNumberField) mField, row, column, locale, mPerspective);
+			break;
+		case BOOLEAN:
+			mField = new MBooleanField();
+			initField(label, required, mField);
+			BooleanField.create(composite, mField, row, column, locale, mPerspective);
+			break;
+		case FILTER:
+			// Sollte nicht vorkommen
+			break;
+		case INSTANT:
+		case ZONED:
+			mField = createInstantField(composite, dateTimeType, row, column, mField, label, required);
+			break;
+		case INTEGER:
+			mField = new MNumberField(0);
+			initField(label, required, mField);
+			NumberField.create(composite, (MNumberField) mField, row, column, locale, mPerspective);
+			break;
+		case REFERENCE:
+			// Sollte nicht vorkommen
+			break;
+		case STRING:
+			mField = new MTextField();
+			initField(label, required, mField);
+			TextField.create(composite, mField, row, column, mPerspective);
+			break;
+		}
+
+		return mField;
+	}
+
+	private void initField(String label, boolean required, MField mField) {
+		mField.setLabel(label);
+		mField.setName(label);
+		mField.setRequired(required);
+		mField.addValueChangeListener(this);
+		mDetail.putField(mField);
+		mField.setMSection(mSection);
+	}
+
+	private MField createInstantField(Composite composite, DateTimeType dateTimeType, int row, int column, MField mField, String label, boolean required) {
+		switch (dateTimeType) {
+		case DATE:
+			mField = new MShortDateField();
+			initField(label, required, mField);
+			ShortDateField.create(composite, mField, row, column, locale, timezone, mPerspective, translationService);
+			break;
+		case DATETIME:
+			mField = new MDateTimeField();
+			initField(label, required, mField);
+			DateTimeField.create(composite, mField, row, column, locale, timezone, mPerspective, translationService);
+			break;
+		case TIME:
+			mField = new MShortTimeField();
+			initField(label, required, mField);
+			ShortTimeField.create(composite, mField, row, column, locale, timezone, mPerspective, translationService);
+			break;
+		}
+		return mField;
+	}
+
+	protected MLookupField createMLookupField() {
+		// TODO
+		return new MLookupField();
+	}
+
+	private static class MinovaWizardPageChangedListener implements IPageChangedListener {
+		@Override
+		public void pageChanged(PageChangedEvent event) {
+			Object selectedPage = event.getSelectedPage();
+			if (selectedPage instanceof MinovaWizardPage) {
+				((MinovaWizardPage) selectedPage).onSelect();
+			}
+		}
+	}
+
+	@Override
+	public void valueChange(ValueChangeEvent evt) {
+		setPageComplete(mDetail.allFieldsAndGridsValid());
 	}
 }

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardPageEnterHelper.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardPageEnterHelper.java
@@ -27,7 +27,7 @@ public class MinovaWizardPageEnterHelper {
 		((AbstractValueAccessor) field.getValueAccessor()).getControl().setFocus();
 	}
 
-	public void selectNewFieldOrSave(MField currentField) {
+	public void selectNextField(MField currentField) {
 		int startIndex = 0;
 		if (!selectFirstRequired) {
 			startIndex = fields.indexOf(currentField) + 1;

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardPageEnterHelper.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/widgets/MinovaWizardPageEnterHelper.java
@@ -1,0 +1,57 @@
+package aero.minova.rcp.rcp.widgets;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.swt.SWTException;
+
+import aero.minova.rcp.model.form.MField;
+import aero.minova.rcp.rcp.accessor.AbstractValueAccessor;
+import aero.minova.rcp.widgets.LookupComposite;
+
+public class MinovaWizardPageEnterHelper {
+
+	private List<MField> fields;
+	boolean selectFirstRequired;
+
+	public MinovaWizardPageEnterHelper(boolean selectFirstRequired) {
+		this.selectFirstRequired = selectFirstRequired;
+		fields = new ArrayList<>();
+	}
+
+	public void addField(MField field) {
+		fields.add(field);
+	}
+
+	public void setFocus(MField field) {
+		((AbstractValueAccessor) field.getValueAccessor()).getControl().setFocus();
+	}
+
+	public void selectNewFieldOrSave(MField currentField) {
+		int startIndex = 0;
+		if (!selectFirstRequired) {
+			startIndex = fields.indexOf(currentField) + 1;
+		}
+
+		// Alle Felder durchgehen, falls eines noch keinen Wert hat dieses auswählen
+		int max = fields.size() + startIndex;
+		while (startIndex < max) {
+			MField f = fields.get(startIndex % fields.size());
+			startIndex++;
+			if (f.getValue() == null && f.isRequired() && !f.isReadOnly()) {
+				try {
+					setFocus(f);
+				} catch (SWTException e) {
+					continue;
+				}
+				return;
+			}
+		}
+
+		// Wenn als letztes ein Popup Fenster offen war, dieses schließen und noch nicht speichern
+		if (((AbstractValueAccessor) currentField.getValueAccessor()).getControl() instanceof LookupComposite) {
+			LookupComposite l = (LookupComposite) ((AbstractValueAccessor) currentField.getValueAccessor()).getControl();
+			l.closePopup();
+		}
+	}
+}


### PR DESCRIPTION
- Den in der Maske gegebenen Wizard aktivieren (bis jetzt wurde immer der erste genutzt)
- MinovaWizard und MinovaWizardPage Klassen vereinfachen und mit Kommentaren versehen (siehe auch #1217)
- Klasse zum Erstellen einer Tabelle im Wizard hinzufügen 
-  Knöpfe "< Back" und "Next >" Übersetzen
- Methoden zum leichten Erstellen von Feldern
- Enter per Default unterstützen
- Enter und Escape bei Lookups verbessern
- MinovaLayout für Felder nutzen closes #1150