### PR TITLE
scr: prepare CI pipeline with SonarQube

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <activeProfiles>
+        <activeProfile>github</activeProfile>
+    </activeProfiles>
+
+    <profiles>
+        <profile>
+            <id>github</id>
+            <repositories>
+                <repository>
+                    <id>github</id>
+                    <name>GitHub</name>
+                    <url>https://maven.pkg.github.com/minova-afis/aero.minova.maven.root</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+
+    <servers>
+        <server>
+            <id>github</id>
+            <username>${MAIN_GITHUB_RELEASE_USERNAME}</username>
+            <password>${MAIN_GITHUB_RELEASE_TOKEN}</password>
+        </server>
+    </servers>
+</settings>

--- a/.github/workflows/maven-macos-win.yml
+++ b/.github/workflows/maven-macos-win.yml
@@ -7,33 +7,64 @@ on:
   push:
     branches:
       - master
+      - scr_sonarqube
   pull_request:
   workflow_dispatch:
+
+env:
+  ACCOUNT: minova-afis
 
 jobs: 
   build:
     runs-on: windows-latest
+
     strategy:
       matrix:
         java: [ '11.0.14' ]
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: 11.0.14
-        distribution: 'temurin'
-    - name: Cache local Maven repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Build with Maven
-      run: mvn clean verify surefire-report:report --fae --file pom.xml
-    - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action/composite@v1
-      if: always()
-      with:
-        files: /**/surefire-reports/*.xml
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11.0.14
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Maven build and SonarQube scan
+        run: |
+          cd $GITHUB_WORKSPACE
+          mvn --batch-mode --no-transfer-progress verify \
+            surefire-report:report --fae
+            dependency-check:aggregate \
+            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+            -Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}} \
+            -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} \ 
+            -DskipTests=true --fae -T4 \
+            --settings .github/settings.xml
+        env:
+          MAIN_GITHUB_RELEASE_USERNAME: ${{ secrets.MAIN_GITHUB_RELEASE_USERNAME }}
+          MAIN_GITHUB_RELEASE_TOKEN: ${{ secrets.MAIN_GITHUB_RELEASE_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        if: always()
+        with:
+          files: /**/surefire-reports/*.xml

--- a/.github/workflows/maven-macos-win.yml
+++ b/.github/workflows/maven-macos-win.yml
@@ -53,7 +53,7 @@ jobs:
             dependency-check:aggregate \
             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
             -Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}} \
-            -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} \ 
+            -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} \
             -DskipTests=true --fae -T4 \
             --settings .github/settings.xml
         env:

--- a/.github/workflows/maven-macos-win.yml
+++ b/.github/workflows/maven-macos-win.yml
@@ -54,8 +54,7 @@ jobs:
             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
             -Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}} \
             -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} \
-            -DskipTests=true --fae -T4 \
-            --settings .github/settings.xml
+            -DskipTests=true --fae -T4 --settings .github/settings.xml
         env:
           MAIN_GITHUB_RELEASE_USERNAME: ${{ secrets.MAIN_GITHUB_RELEASE_USERNAME }}
           MAIN_GITHUB_RELEASE_TOKEN: ${{ secrets.MAIN_GITHUB_RELEASE_TOKEN }}

--- a/.github/workflows/maven-macos-win.yml
+++ b/.github/workflows/maven-macos-win.yml
@@ -11,9 +11,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  ACCOUNT: minova-afis
-
 jobs: 
   build:
     runs-on: windows-latest
@@ -23,47 +20,24 @@ jobs:
         java: [ '11.0.14' ]
 
     steps:
-      - name: Get branch name
-        id: branch-name
-        uses: tj-actions/branch-names@v5.1
+    - uses: actions/checkout@v3
 
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: 11.0.14
+        distribution: 'temurin'
+        cache: 'maven'
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        with:
-          java-version: 11.0.14
-          distribution: 'temurin'
-          cache: 'maven'
+    - name: Build with Maven
+      run: |
+        mvn clean verify surefire-report:report --fae --file pom.xml --settings .github/settings.xml
+      env:
+        MAIN_GITHUB_RELEASE_USERNAME: ${{ secrets.MAIN_GITHUB_RELEASE_USERNAME }}
+        MAIN_GITHUB_RELEASE_TOKEN: ${{ secrets.MAIN_GITHUB_RELEASE_TOKEN }}
 
-      - name: Cache SonarQube packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Maven build and SonarQube scan
-        run: |
-          cd $GITHUB_WORKSPACE
-          mvn --batch-mode --no-transfer-progress verify \
-            surefire-report:report --fae
-            dependency-check:aggregate \
-            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
-            -Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}} \
-            -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} \
-            -DskipTests=true --fae -T4 --settings .github/settings.xml
-        env:
-          MAIN_GITHUB_RELEASE_USERNAME: ${{ secrets.MAIN_GITHUB_RELEASE_USERNAME }}
-          MAIN_GITHUB_RELEASE_TOKEN: ${{ secrets.MAIN_GITHUB_RELEASE_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v1
-        if: always()
-        with:
-          files: /**/surefire-reports/*.xml
+    - name: Publish Unit Test Results
+      uses: EnricoMi/publish-unit-test-result-action/composite@v1
+      if: always()
+      with:
+        files: /**/surefire-reports/*.xml

--- a/.github/workflows/maven-macos-win.yml
+++ b/.github/workflows/maven-macos-win.yml
@@ -19,7 +19,13 @@ jobs:
         java: [ '11.0.14' ]
 
     steps:
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
+
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -27,6 +33,13 @@ jobs:
           java-version: 11.0.14
           distribution: 'temurin'
           cache: 'maven'
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
 
       - name: Build with Maven
         run: |

--- a/.github/workflows/maven-macos-win.yml
+++ b/.github/workflows/maven-macos-win.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  ACCOUNT: minova-afis
+
 jobs: 
   build:
     runs-on: windows-latest
@@ -41,9 +44,9 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      - name: Build with Maven
+      - name: Build with Maven and SonarQube scan
         run: |
-          mvn clean verify -P all-tests dependency-check:aggregate org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}} -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} surefire-report:report --fae --file pom.xml --settings .github/settings.xml
+          mvn --batch-mode --no-transfer-progress clean verify -P all-tests dependency-check:aggregate org.sonarsource.scanner.maven:sonar-maven-plugin:sonar "-Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}}" "-Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}}" surefire-report:report --fae --file pom.xml --settings .github/settings.xml
         env:
           MAIN_GITHUB_RELEASE_USERNAME: ${{ secrets.MAIN_GITHUB_RELEASE_USERNAME }}
           MAIN_GITHUB_RELEASE_TOKEN: ${{ secrets.MAIN_GITHUB_RELEASE_TOKEN }}

--- a/.github/workflows/maven-macos-win.yml
+++ b/.github/workflows/maven-macos-win.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - scr_sonarqube
   pull_request:
   workflow_dispatch:
 
@@ -20,24 +19,33 @@ jobs:
         java: [ '11.0.14' ]
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: 11.0.14
-        distribution: 'temurin'
-        cache: 'maven'
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11.0.14
+          distribution: 'temurin'
+          cache: 'maven'
 
-    - name: Build with Maven
-      run: |
-        mvn clean verify surefire-report:report --fae --file pom.xml --settings .github/settings.xml
-      env:
-        MAIN_GITHUB_RELEASE_USERNAME: ${{ secrets.MAIN_GITHUB_RELEASE_USERNAME }}
-        MAIN_GITHUB_RELEASE_TOKEN: ${{ secrets.MAIN_GITHUB_RELEASE_TOKEN }}
+      - name: Build with Maven
+        run: |
+          mvn clean verify -P all-tests dependency-check:aggregate org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}} -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} surefire-report:report --fae --file pom.xml --settings .github/settings.xml
+        env:
+          MAIN_GITHUB_RELEASE_USERNAME: ${{ secrets.MAIN_GITHUB_RELEASE_USERNAME }}
+          MAIN_GITHUB_RELEASE_TOKEN: ${{ secrets.MAIN_GITHUB_RELEASE_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
 
-    - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action/composite@v1
-      if: always()
-      with:
-        files: /**/surefire-reports/*.xml
+      - name: Store report of Dependency Check
+        uses: actions/upload-artifact@v2
+        with:
+          name: dependency-check-report.html
+          path: target/dependency-check-report.html
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        if: always()
+        with:
+          files: /**/surefire-reports/*.xml

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -52,7 +52,7 @@ jobs:
             dependency-check:aggregate \
             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
             -Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}} \
-            -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} \ 
+            -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} \
             -DskipTests=true --fae -T4 \
             --file pom.xml \
             --settings .github/settings.xml

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Maven build and SonarQube scan
         run: |
           cd $GITHUB_WORKSPACE
-          xvfb-run -- \
+#          xvfb-run -- \
           mvn -U --batch-mode --no-transfer-progress \
             clean verify \
             dependency-check:aggregate \

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Maven build and SonarQube scan
         run: |
           cd $GITHUB_WORKSPACE
-#          xvfb-run -- \
           mvn -U --batch-mode --no-transfer-progress \
             clean verify \
             dependency-check:aggregate \

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           xvfb-run -- \
-          mvn --batch-mode --no-transfer-progress \
+          mvn -X --batch-mode --no-transfer-progress \
             clean verify \
             dependency-check:aggregate \
             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - scr_sonarqube
   pull_request:
   workflow_dispatch:
 
@@ -53,8 +52,7 @@ jobs:
             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
             -Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}} \
             -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} \
-            -P all-tests \
-            --fae -T4 \
+            -DskipTests=true --fae -T4 \
             --file pom.xml \
             --settings .github/settings.xml
         env:

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -53,7 +53,8 @@ jobs:
             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
             -Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}} \
             -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} \
-            -DskipTests=true --fae -T4 \
+            -P all-tests \
+            --fae -T4 \
             --file pom.xml \
             --settings .github/settings.xml
         env:

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  ACCOUNT: minova-afis
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -36,37 +33,17 @@ jobs:
 
       - run: sudo apt-get install xvfb
 
-      - name: Cache SonarQube packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Maven build and SonarQube scan
+      - name: Maven build
         run: |
           cd $GITHUB_WORKSPACE
           xvfb-run -- \
           mvn --batch-mode --no-transfer-progress verify \
-            dependency-check:aggregate \
-            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
-            -Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}} \
-            -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} \
             -DskipTests=true --fae -T4 \
             --file pom.xml \
             --settings .github/settings.xml
         env:
           MAIN_GITHUB_RELEASE_USERNAME: ${{ secrets.MAIN_GITHUB_RELEASE_USERNAME }}
           MAIN_GITHUB_RELEASE_TOKEN: ${{ secrets.MAIN_GITHUB_RELEASE_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
-
-      - name: Store report of Dependency Check
-        uses: actions/upload-artifact@v2
-        with:
-          name: dependency-check-report.html
-          path: target/dependency-check-report.html
 
 #    - uses: actions/upload-artifact@v2
 #      with:

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -53,7 +53,8 @@ jobs:
 
       - name: Maven build and SonarQube scan
         run: |
-          xvfb-run \
+          cd $GITHUB_WORKSPACE
+          xvfb-run -- \
           mvn --batch-mode --no-transfer-progress \
             clean verify \
             dependency-check:aggregate \

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - scr_sonarqube
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -10,27 +10,68 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  ACCOUNT: minova-afis
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: 11
-        distribution: 'adopt'
-    - run: sudo apt-get install xvfb
-    - name: Cache local Maven repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Build with Maven
-      run: xvfb-run mvn clean verify -DskipTests=true --fae --file pom.xml -T4
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'adopt'
+          java-package: 'jdk'
+          cache: 'maven'
+
+      - run: sudo apt-get install xvfb
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Maven build and SonarQube scan
+        run: |
+          xvfb-run \
+          mvn --batch-mode --no-transfer-progress \
+            clean verify \
+            dependency-check:aggregate \
+            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+            -Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}} \
+            -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} \ 
+            -DskipTests=true --fae -T4 \
+            --file pom.xml
+        env:
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
+
+      - name: Store report of Dependency Check
+        uses: actions/upload-artifact@v2
+        with:
+          name: dependency-check-report.html
+          path: target/dependency-check-report.html
 
 #    - uses: actions/upload-artifact@v2
 #      with:

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Maven build and SonarQube scan
         run: |
           cd $GITHUB_WORKSPACE
-          mvn -U --batch-mode --no-transfer-progress \
-            clean verify \
+          xvfb-run -- \
+          mvn --batch-mode --no-transfer-progress verify \
             dependency-check:aggregate \
             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
             -Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}} \

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -61,8 +61,11 @@ jobs:
             -Dsonar.projectKey=${{env.ACCOUNT}}_${{github.event.repository.name}} \
             -Dsonar.branch.name=${{steps.branch-name.outputs.current_branch}} \ 
             -DskipTests=true --fae -T4 \
-            --file pom.xml
+            --file pom.xml \
+            --settings .github/settings.xml
         env:
+          MAIN_GITHUB_RELEASE_USERNAME: ${{ secrets.MAIN_GITHUB_RELEASE_USERNAME }}
+          MAIN_GITHUB_RELEASE_TOKEN: ${{ secrets.MAIN_GITHUB_RELEASE_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -36,14 +36,6 @@ jobs:
 
       - run: sudo apt-get install xvfb
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Cache SonarQube packages
         uses: actions/cache@v1
         with:
@@ -55,7 +47,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           xvfb-run -- \
-          mvn -X --batch-mode --no-transfer-progress \
+          mvn -U --batch-mode --no-transfer-progress \
             clean verify \
             dependency-check:aggregate \
             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \

--- a/Changelog.adoc
+++ b/Changelog.adoc
@@ -14,6 +14,9 @@ Der entsprechende Abschnitt des Changelogs wird auch jeweils in die link:https:/
 
 ## [Unreleased]
 
+### Neu
+- CI pipeline mit SonarQube einrichten
+
 ### Änderung
 - Index nach Blockieren neu Laden, wenn Einstellung gesetzt ist
 - Aufruf zum Auflisten der Werte bei Read-Only Lookups nicht ausführen
@@ -25,6 +28,7 @@ Der entsprechende Abschnitt des Changelogs wird auch jeweils in die link:https:/
 - Tests für ValueDe-/Serializer
 - Unnötige Tests für die Anzahl an TimeZones entfernen, PreferencewindowTests beim Bauen ausführen
 - Einstellung des Dark-Modes unter MacOS ignorieren
+
 
 ### Bugfixes
 - Auswahl von Radioboxen komplett entfernen, wenn ein bereits ausgewähltes Element geklickt wird 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
 
         <sonar.coverage.jacoco.xmlReportPaths>
-            ${project.basedir}/report-aggregate/target/site/jacoco-aggregate/jacoco.xml
+            ${project.basedir}/../report-aggregate/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,164 +1,183 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>aero.minova.rcp</groupId>
-	<artifactId>aero.minova.rcp.root</artifactId>
-	<version>12.2.1-SNAPSHOT</version>
-	<name>aero.minova.rcp</name>
-	<packaging>pom</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>aero.minova.rcp</groupId>
+    <artifactId>aero.minova.rcp.root</artifactId>
+    <version>12.2.1-SNAPSHOT</version>
+    <name>aero.minova.rcp</name>
+    <packaging>pom</packaging>
 
-	<parent>
-		<groupId>aero.minova</groupId>
-		<artifactId>spring.maven.root</artifactId>
-		<version>1.3.4</version>
-		<relativePath />
-	</parent>
+    <parent>
+        <groupId>aero.minova</groupId>
+        <artifactId>spring.maven.root</artifactId>
+        <version>1.3.4</version>
+        <relativePath/>
+    </parent>
 
-	<properties>
-		<tycho.version>2.7.4</tycho.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.javadoc.skip>true</maven.javadoc.skip>
-	</properties>
+    <properties>
+        <tycho.version>2.7.4</tycho.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
 
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-source-plugin</artifactId>
-					<version>3.2.1</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.4.0</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-deploy-plugin</artifactId>
-					<version>3.0.0</version>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-maven-plugin</artifactId>
-				<version>${tycho.version}</version>
-				<extensions>true</extensions>
-			</plugin>
-			<!--Enable the replacement of the SNAPSHOT version in the final product configuration -->
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-packaging-plugin</artifactId>
-				<version>${tycho.version}</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<id>package-feature</id>
-						<configuration>
-							<finalName>${project.artifactId}_${unqualifiedVersion}.${buildQualifier}</finalName>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<!-- tag::target-definition[] -->
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>target-platform-configuration</artifactId>
-				<version>${tycho.version}</version>
-				<configuration>
-					<target>
-						<artifact>
-							<groupId>aero.minova.rcp</groupId>
-							<artifactId>eclipse-2021-09</artifactId>
-							<version>1.0.1-SNAPSHOT</version>
-						</artifact>
-					</target>
-					<resolveWithExecutionEnvironmentConstraints>false</resolveWithExecutionEnvironmentConstraints>
-					<!-- end::target-definition[] -->
-					<environments>
-						<environment>
-							<os>linux</os>
-							<ws>gtk</ws>
-							<arch>x86_64</arch>
-						</environment>
-						<environment>
-							<os>win32</os>
-							<ws>win32</ws>
-							<arch>x86_64</arch>
-						</environment>
-						<environment>
-							<os>macosx</os>
-							<ws>cocoa</ws>
-							<arch>x86_64</arch>
-						</environment>
-					</environments>
-				</configuration>
-			</plugin>
-		<!-- To define the plugin version in your parent POM -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.3</version>
-				<configuration>
-					<preparationGoals>org.eclipse.tycho:tycho-versions-plugin:${tycho.version}:update-eclipse-metadata
-						org.apache.maven.plugins:maven-scm-plugin:1.9.5:add
-						org.apache.maven.plugins:maven-scm-plugin:1.9.5:checkin</preparationGoals>
-					<completionGoals>org.eclipse.tycho:tycho-versions-plugin:${tycho.version}:update-eclipse-metadata
-						org.apache.maven.plugins:maven-scm-plugin:1.9.5:add
-						org.apache.maven.plugins:maven-scm-plugin:1.9.5:checkin</completionGoals>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-scm-plugin</artifactId>
-				<version>1.13.0</version>
-				<executions>
-					<execution>
-						<id>default-cli</id>
-						<goals>
-							<goal>add</goal>
-							<goal>checkin</goal>
-						</goals>
-						<configuration>
-							<includes>**/META-INF/MANIFEST.MF, **/feature.xml,
-								**/*.product,**/category.xml</includes>
-							<excludes>**/target/**,**/.polyglot*</excludes>
-							<message>Changing the Eclipse files versions</message>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+    <dependencies>
+        <dependency>
+            <!--  must be on the classpath test coverage  -->
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <version>0.8.8</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.2.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.4.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-maven-plugin</artifactId>
+                <version>${tycho.version}</version>
+                <extensions>true</extensions>
+            </plugin>
+            <!--Enable the replacement of the SNAPSHOT version in the final product configuration -->
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-packaging-plugin</artifactId>
+                <version>${tycho.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <id>package-feature</id>
+                        <configuration>
+                            <finalName>${project.artifactId}_${unqualifiedVersion}.${buildQualifier}</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- tag::target-definition[] -->
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>target-platform-configuration</artifactId>
+                <version>${tycho.version}</version>
+                <configuration>
+                    <target>
+                        <artifact>
+                            <groupId>aero.minova.rcp</groupId>
+                            <artifactId>eclipse-2021-09</artifactId>
+                            <version>1.0.1-SNAPSHOT</version>
+                        </artifact>
+                    </target>
+                    <resolveWithExecutionEnvironmentConstraints>false</resolveWithExecutionEnvironmentConstraints>
+                    <!-- end::target-definition[] -->
+                    <environments>
+                        <environment>
+                            <os>linux</os>
+                            <ws>gtk</ws>
+                            <arch>x86_64</arch>
+                        </environment>
+                        <environment>
+                            <os>win32</os>
+                            <ws>win32</ws>
+                            <arch>x86_64</arch>
+                        </environment>
+                        <environment>
+                            <os>macosx</os>
+                            <ws>cocoa</ws>
+                            <arch>x86_64</arch>
+                        </environment>
+                    </environments>
+                </configuration>
+            </plugin>
+            <!-- To define the plugin version in your parent POM -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <preparationGoals>org.eclipse.tycho:tycho-versions-plugin:${tycho.version}:update-eclipse-metadata
+                        org.apache.maven.plugins:maven-scm-plugin:1.9.5:add
+                        org.apache.maven.plugins:maven-scm-plugin:1.9.5:checkin
+                    </preparationGoals>
+                    <completionGoals>org.eclipse.tycho:tycho-versions-plugin:${tycho.version}:update-eclipse-metadata
+                        org.apache.maven.plugins:maven-scm-plugin:1.9.5:add
+                        org.apache.maven.plugins:maven-scm-plugin:1.9.5:checkin
+                    </completionGoals>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-scm-plugin</artifactId>
+                <version>1.13.0</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <goals>
+                            <goal>add</goal>
+                            <goal>checkin</goal>
+                        </goals>
+                        <configuration>
+                            <includes>**/META-INF/MANIFEST.MF, **/feature.xml,
+                                **/*.product,**/category.xml
+                            </includes>
+                            <excludes>**/target/**,**/.polyglot*</excludes>
+                            <message>Changing the Eclipse files versions</message>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 
-	<distributionManagement>
-		<repository>
-			<id>nexus</id>
-			<name>Internal Releases</name>
-			<url>http://nexus.minova.com:8081/nexus/content/repositories/releases/</url>
-		</repository>
-		<snapshotRepository>
-			<id>nexus</id>
-			<name>Internal Snapshots</name>
-			<url>http://nexus.minova.com:8081/nexus/content/repositories/snapshots/</url>
-		</snapshotRepository>
-	</distributionManagement>
+    <distributionManagement>
+        <repository>
+            <id>nexus</id>
+            <name>Internal Releases</name>
+            <url>http://nexus.minova.com:8081/nexus/content/repositories/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>nexus</id>
+            <name>Internal Snapshots</name>
+            <url>http://nexus.minova.com:8081/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
 
-	<scm>
-		<connection>scm:git:https://github.com/minova-afis/aero.minova.rcp.git</connection>
-		<developerConnection>scm:git:https://github.com/minova-afis/aero.minova.rcp.git</developerConnection>
-		<tag>aero.minova.rcp.root-0.1.0</tag>
-	</scm>
+    <scm>
+        <connection>scm:git:https://github.com/minova-afis/aero.minova.rcp.git</connection>
+        <developerConnection>scm:git:https://github.com/minova-afis/aero.minova.rcp.git</developerConnection>
+        <tag>aero.minova.rcp.root-0.1.0</tag>
+    </scm>
 
-	
-	<modules>
-		<module>bundles</module>
-		<module>features</module>
-		<module>releng</module>
-		<module>libs</module>
-		<module>tests</module>
 
-	</modules>
+    <modules>
+        <module>bundles</module>
+        <module>features</module>
+        <module>releng</module>
+        <module>libs</module>
+        <module>tests</module>
+
+    </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,18 +18,11 @@
         <tycho.version>2.7.4</tycho.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-    </properties>
 
-    <dependencies>
-        <dependency>
-            <!--  must be on the classpath test coverage  -->
-            <groupId>org.jacoco</groupId>
-            <artifactId>org.jacoco.agent</artifactId>
-            <classifier>runtime</classifier>
-            <version>0.8.8</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.basedir}/report-aggregate/target/site/jacoco-aggregate/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
+    </properties>
 
     <build>
         <pluginManagement>
@@ -144,10 +137,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 
@@ -179,5 +168,6 @@
         <module>libs</module>
         <module>tests</module>
 
+        <module>report-aggregate</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
 
         <sonar.coverage.jacoco.xmlReportPaths>
-            ${project.basedir}/../report-aggregate/target/site/jacoco-aggregate/jacoco.xml
+            ${project.basedir}/report-aggregate/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,15 @@
 	<groupId>aero.minova.rcp</groupId>
 	<artifactId>aero.minova.rcp.root</artifactId>
 	<version>12.2.1-SNAPSHOT</version>
-	<name>[mvn] Root</name>
+	<name>aero.minova.rcp</name>
 	<packaging>pom</packaging>
+
+	<parent>
+		<groupId>aero.minova</groupId>
+		<artifactId>spring.maven.root</artifactId>
+		<version>1.3.4</version>
+		<relativePath />
+	</parent>
 
 	<properties>
 		<tycho.version>2.7.4</tycho.version>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>aero.minova.rcp.tests</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>aero.minova.rcp.report-aggregate</artifactId>
+    <description>Aggregate Coverage Report</description>
 
     <parent>
         <groupId>aero.minova.rcp</groupId>
@@ -11,20 +11,21 @@
         <relativePath>../</relativePath>
     </parent>
 
-    <modules>
-        <module>aero.minova.rcp.rcp.tests</module>
-        <module>aero.minova.rcp.xml.tests</module>
-        <module>aero.minova.rcp.uitests</module>
-    </modules>
-
     <dependencies>
         <dependency>
-            <!--  must be on the classpath test coverage  -->
-            <groupId>org.jacoco</groupId>
-            <artifactId>org.jacoco.agent</artifactId>
-            <classifier>runtime</classifier>
-            <version>0.8.8</version>
-            <scope>test</scope>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>aero.minova.rcp.xml.tests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>aero.minova.rcp.rcp.tests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>aero.minova.rcp.uitests</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 
@@ -40,11 +41,6 @@
                         <goals>
                             <goal>report-aggregate</goal>
                         </goals>
-                        <configuration>
-                            <formats>
-                                <format>XML</format>
-                            </formats>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/tests/aero.minova.rcp.rcp.tests/pom.xml
+++ b/tests/aero.minova.rcp.rcp.tests/pom.xml
@@ -1,31 +1,32 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
 http://maven.apache.org/maven-v4_0_0.xsd">
-<modelVersion>4.0.0</modelVersion>
-	<groupId>aero.minova.rcp</groupId>
-	<artifactId>aero.minova.rcp.rcp.tests</artifactId>
-	<version>12.2.1-SNAPSHOT</version>
-	<packaging>eclipse-test-plugin</packaging>
-	<parent>
-		<groupId>aero.minova.rcp</groupId>
-		<artifactId>aero.minova.rcp.tests</artifactId>
-		<version>12.2.1-SNAPSHOT</version>
-	</parent>
-	<build>
-		<plugins>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>aero.minova.rcp</groupId>
+    <artifactId>aero.minova.rcp.rcp.tests</artifactId>
+    <version>12.2.1-SNAPSHOT</version>
+    <packaging>eclipse-test-plugin</packaging>
 
-		<plugin>
-		 <groupId>org.eclipse.tycho</groupId>
-		 <artifactId>tycho-surefire-plugin</artifactId>
-		 <version>${tycho.version}</version>
-			<configuration>
-				<excludes>
-          			<!-- Tests trying to access the server-->
-          			<exclude>DetailUtilTests</exclude>
-				</excludes>
-			</configuration>
-		</plugin>
-		</plugins>
-	</build>	
+    <parent>
+        <groupId>aero.minova.rcp</groupId>
+        <artifactId>aero.minova.rcp.tests</artifactId>
+        <version>12.2.1-SNAPSHOT</version>
+    </parent>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <version>${tycho.version}</version>
+                <configuration>
+                    <excludes>
+                        <!-- Tests trying to access the server-->
+                        <exclude>DetailUtilTests</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/tests/aero.minova.rcp.uitests/pom.xml
+++ b/tests/aero.minova.rcp.uitests/pom.xml
@@ -1,72 +1,71 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>aero.minova.rcp</groupId>
-	<artifactId>aero.minova.rcp.uitests</artifactId>
-	<version>12.2.1-SNAPSHOT</version>
-	
-	<packaging>eclipse-test-plugin</packaging>
-	
-	<parent>
-		<groupId>aero.minova.rcp</groupId>
-		<artifactId>aero.minova.rcp.tests</artifactId>
-		<version>12.2.1-SNAPSHOT</version>
-	</parent>
-	
-	<properties>
-		<uitest.vmparams>-Xms256m -Xmx8096m -Dfile.encoding=UTF-8</uitest.vmparams>
-	</properties>
-	
-	
-	<profiles>
-		<profile>
-			<id>macosx</id>
-			<activation>
-				<os>
-					<family>mac</family>
-				</os>
-			</activation>
-			<properties>
-				<ui.test.vmargs>${uitest.vmparams} -XstartOnFirstThread</ui.test.vmargs>
-			</properties>
-		</profile>
-		<profile>
-			<id>other-os</id>
-			<activation>
-				<os>
-					<family>!mac</family>
-				</os>
-			</activation>
-			<properties>
-				<ui.test.vmargs>${uitest.vmparams}</ui.test.vmargs>
-			</properties>
-		</profile>
-	</profiles>
+    <groupId>aero.minova.rcp</groupId>
+    <artifactId>aero.minova.rcp.uitests</artifactId>
+    <version>12.2.1-SNAPSHOT</version>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-surefire-plugin</artifactId>
-				<version>${tycho.version}</version>
-				<configuration>
-					<argLine>${ui.test.vmargs}</argLine>
-					<appArgLine>-nl de -clearPersistedState -consoleLog -user=admin -pw=rqgzxTf71EAx8chvchMi -url=http://publictest.minova.com:17280/cas</appArgLine>
-					<useUIHarness>true</useUIHarness>
-					<useUIThread>false</useUIThread>
-					<product>aero.minova.rcp.rcp.product</product>
-					<application>org.eclipse.e4.ui.workbench.swt.E4Application</application>
-					
-					<!--
-					<testSuite>org.eclipse.swtbot.e4.finder.test</testSuite>
-					<testClass>org.eclipse.swtbot.e4.finder.test.AllTests</testClass>
-					-->
-					<trimStackTrace>false</trimStackTrace>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <packaging>eclipse-test-plugin</packaging>
+
+    <parent>
+        <groupId>aero.minova.rcp</groupId>
+        <artifactId>aero.minova.rcp.tests</artifactId>
+        <version>12.2.1-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <uitest.vmparams>-Xms256m -Xmx8096m -Dfile.encoding=UTF-8</uitest.vmparams>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>macosx</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                </os>
+            </activation>
+            <properties>
+                <ui.test.vmargs>${uitest.vmparams} -XstartOnFirstThread</ui.test.vmargs>
+            </properties>
+        </profile>
+        <profile>
+            <id>other-os</id>
+            <activation>
+                <os>
+                    <family>!mac</family>
+                </os>
+            </activation>
+            <properties>
+                <ui.test.vmargs>${uitest.vmparams}</ui.test.vmargs>
+            </properties>
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <version>${tycho.version}</version>
+                <configuration>
+                    <argLine>${ui.test.vmargs}</argLine>
+                    <appArgLine>-nl de -clearPersistedState -consoleLog -user=admin -pw=rqgzxTf71EAx8chvchMi -url=http://publictest.minova.com:17280/cas
+                    </appArgLine>
+                    <useUIHarness>true</useUIHarness>
+                    <useUIThread>false</useUIThread>
+                    <product>aero.minova.rcp.rcp.product</product>
+                    <application>org.eclipse.e4.ui.workbench.swt.E4Application</application>
+
+                    <!--
+                    <testSuite>org.eclipse.swtbot.e4.finder.test</testSuite>
+                    <testClass>org.eclipse.swtbot.e4.finder.test.AllTests</testClass>
+                    -->
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/tests/aero.minova.rcp.xml.tests/pom.xml
+++ b/tests/aero.minova.rcp.xml.tests/pom.xml
@@ -1,33 +1,34 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
 http://maven.apache.org/maven-v4_0_0.xsd">
-<modelVersion>4.0.0</modelVersion>
-	<groupId>aero.minova.rcp</groupId>
-	<artifactId>aero.minova.rcp.xml.tests</artifactId>
-	<packaging>eclipse-test-plugin</packaging>
-	<parent>
-		<groupId>aero.minova.rcp</groupId>
-		<artifactId>aero.minova.rcp.tests</artifactId>
-		<version>12.2.1-SNAPSHOT</version>
-	</parent>
-	<build>
-		<plugins>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>aero.minova.rcp</groupId>
+    <artifactId>aero.minova.rcp.xml.tests</artifactId>
+    <packaging>eclipse-test-plugin</packaging>
 
-		<plugin>
-		 <groupId>org.eclipse.tycho</groupId>
-		 <artifactId>tycho-surefire-plugin</artifactId>
-		 <version>${tycho.version}</version>
-			<configuration>
-				<argLine>-Dfile.encoding=UTF-8</argLine>
-				<excludes>
-          			<!-- Tests trying to access the server-->
-          			<exclude>ReadDetailFromMaskTest</exclude>
-				</excludes>
-			</configuration>
-		</plugin>
-		</plugins>
-	</build>	
+    <parent>
+        <groupId>aero.minova.rcp</groupId>
+        <artifactId>aero.minova.rcp.tests</artifactId>
+        <version>12.2.1-SNAPSHOT</version>
+    </parent>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <version>${tycho.version}</version>
+                <configuration>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                    <excludes>
+                        <!-- Tests trying to access the server-->
+                        <exclude>ReadDetailFromMaskTest</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>
 
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -12,11 +12,11 @@
     </parent>
 
     <modules>
+        <module>aero.minova.rcp.model.tests</module>
         <module>aero.minova.rcp.rcp.tests</module>
-        <module>aero.minova.rcp.xml.tests</module>
         <module>aero.minova.rcp.uitests</module>
         <module>aero.minova.rcp.preferencewindow.tests</module>
-    		<module>aero.minova.rcp.xml.tests</module>
+        <module>aero.minova.rcp.xml.tests</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
Es gibt immer noch Probleme beim der Anzeige der Coverage durch SonarQube (https://docs.sonarqube.org/latest/analysis/test-coverage/java-test-coverage/):
* Beim Workflow `maven-ubuntu.yml` werden die Tests übersprungen (`-DskipTests`)
* Auf meinem Rechner `MacOS` wird die Coverage von SonarQube angezeigt. Hurra!
* Beim Workflow `maven-macos-win.yml` wird auf der Build-Platform `windows` leider die Datei `./report-aggregate/target/site/jacoco-aggregate/jacoco.xml` gelesen, aber nicht korrekt ausgewertet.

```
[INFO] Sensor com.github.mc1arke.sonarqube.plugin.scanner.ScannerPullRequestPropertySensor (done) | time=0ms
[INFO] ------------- Run sensors on module aero.minova.rcp
[INFO] Sensor JaCoCo XML Report Importer [jacoco]
[INFO] Importing 1 report(s). Turn your logs in debug mode in order to see the exhaustive list.
[INFO] Sensor JaCoCo XML Report Importer [jacoco] (done) | time=63ms
[INFO] Sensor CSS Rules [javascript]
[INFO] No CSS, PHP, HTML or VueJS files are found in the project. CSS analysis is skipped.
```
![Bildschirmfoto 2022-07-27 um 18 36 16](https://user-images.githubusercontent.com/95353437/181301846-f64ff0c4-023c-4d57-9509-42476a1888c4.png)

Da das Herumprobieren ziemlich viel Zeit gekostet hat, würde ich dieses PR erstmal ohne finalen Erfolg zum Review einstellen.