### PR TITLE
Bei nicht-pflicht Lookups einzigen Wert nicht automatisch eintragen

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,7 @@ Der entsprechende Abschnitt des Changelogs wird auch jeweils in die [Releasenote
 - Nicht mehr benötigte und fehlerhafte Datei AFIS_MDI.mdi entfernen
 - Mehrere Helper pro Maske unterstützen, auch Helper aus OPs nutzen
 - Fehler bei Login Loggen, Verwirrende Meldung ("too many authentication attempts") entfernen 
+- Bei nicht-pflicht Lookups einzigen Wert nicht automatisch eintragen
 
 ### Bugfixes
 - Auswahl von Radioboxen komplett entfernen, wenn ein bereits ausgewähltes Element geklickt wird 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/LookupValueAccessor.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/accessor/LookupValueAccessor.java
@@ -146,7 +146,7 @@ public class LookupValueAccessor extends AbstractValueAccessor {
 		try {
 			List<LookupValue> l = listLookup.get();
 			up.getContentProvider().setValuesOnly(l);
-			if (l.size() == 1) {
+			if (l.size() == 1 && field.isRequired()) {
 				field.setValue(l.get(0), true);
 			}
 		} catch (ExecutionException e) {


### PR DESCRIPTION
für #1358

Siehe auch Kommentar https://github.com/minova-afis/aero.minova.rcp/issues/1358#issuecomment-1217944700