### PR TITLE
Methode callProcedureWithTable deprecaten

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,9 @@ Der entsprechende Abschnitt des Changelogs wird auch jeweils in die [Releasenote
 ### Neu
 - use-Resolve-Parms Eigenschaft kann ab jetzt in den Lookups verwendet werden. Damit werden die übergebenen Paramter auch in die Resolve-Prozedur übergeben. Zuvor war dies nur für die List-prozeduren möglich!
 
+### Änderung
+- Methode callProcedureWithTable deprecated
+
 
 ## [12.5.0] - 21.11.2022
 

--- a/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
+++ b/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
@@ -99,12 +99,20 @@ public class Constants {
 	 * Benutzt mit einem String, öffnet einen einfachen Fehler-Dialog
 	 */
 	public static final String BROKER_SHOWERRORMESSAGE = "aero/minova/rcp/ShowErrorMessage";
+
+	@Deprecated
 	public static final String BROKER_PROCEDUREWITHTABLE = "aero/minova/rcp/ProcedureWithTable";
+	@Deprecated
 	public static final String BROKER_PROCEDUREWITHTABLEERROR = "aero/minova/rcp/ProcedureWithTableError";
+	@Deprecated
 	public static final String BROKER_PROCEDUREWITHTABLESUCCESS = "aero/minova/rcp/ProcedureWithTableSuccess";
+	@Deprecated
 	public static final String BROKER_PROCEDUREWITHTABLESUCCESSFINISHED = "aero/minova/rcp/ProcedureWithTableSuccessFinished";
+	@Deprecated
 	public static final String BROKER_PROCEDUREWITHTABLEEMPTYRESPONSE = "aero/minova/rcp/ProcedureWithTableEmptyResponse";
+	@Deprecated
 	public static final String BROKER_SELECTSTATISTIC = "aero/minova/rcp/SelectStatistic";
+
 	public static final String BROKER_SENDEVENTTOHELPER = "aero/minova/rcp/SendEventToHelper";
 	public static final String BROKER_UPDATECOLUMNS = "aero/minova/rcp/UpdateColumns";
 

--- a/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
+++ b/bundles/aero.minova.rcp.constant/src/aero/minova/rcp/constants/Constants.java
@@ -110,9 +110,8 @@ public class Constants {
 	public static final String BROKER_PROCEDUREWITHTABLESUCCESSFINISHED = "aero/minova/rcp/ProcedureWithTableSuccessFinished";
 	@Deprecated
 	public static final String BROKER_PROCEDUREWITHTABLEEMPTYRESPONSE = "aero/minova/rcp/ProcedureWithTableEmptyResponse";
-	@Deprecated
-	public static final String BROKER_SELECTSTATISTIC = "aero/minova/rcp/SelectStatistic";
 
+	public static final String BROKER_SELECTSTATISTIC = "aero/minova/rcp/SelectStatistic";
 	public static final String BROKER_SENDEVENTTOHELPER = "aero/minova/rcp/SendEventToHelper";
 	public static final String BROKER_UPDATECOLUMNS = "aero/minova/rcp/UpdateColumns";
 

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/WFCDetailCASRequestsUtil.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/WFCDetailCASRequestsUtil.java
@@ -762,10 +762,13 @@ public class WFCDetailCASRequestsUtil {
 	/**
 	 * Ruft eine Prozedur mit der übergebenen Tabelle auf. Über den Broker kann auf die Ergebnisse gehört werden
 	 *
+	 * @deprecated Diese Methiode sollte nicht verwendet werden, da sie recht umständlich ist. Stattdessen einfach die Prozedur über den DataService direkt
+	 *             aufrufen.
 	 * @param table
 	 */
 	@Inject
 	@Optional
+	@Deprecated(since = "12.6.0", forRemoval = true)
 	public void callProcedureWithTable(@UIEventTopic(Constants.BROKER_PROCEDUREWITHTABLE) Table table) {
 		MPerspective activePerspective = model.getActivePerspective(partContext.get(MWindow.class));
 		if (activePerspective.equals(perspective) && table != null) {


### PR DESCRIPTION
wurde im Workingtime Helper benutzt, dort nicht mehr benötigt