### PR TITLE
Maximalbreite für Nattable Spalten einführen

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ Der entsprechende Abschnitt des Changelogs wird auch jeweils in die [Releasenote
 - Warnungen entfernen, Code bereinigen
 - Nummernfelder etwas verkleinern, um Einheiten mehr Platz zu geben
 - Tests unter Linux wieder aktivieren
+- Nattable Spalten mit maximal Breite 3000 wiederherstellen
 
 ### Bugfixes
 - Tab in Statistik-Part ausbessern

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCNattablePart.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/parts/WFCNattablePart.java
@@ -658,14 +658,21 @@ public abstract class WFCNattablePart extends WFCFormPart {
 			int position = Integer.parseInt(keyValue[0].trim());
 			int width = Integer.parseInt(keyValue[1].trim());
 			order.add(position);
+
+			// Unter Mac werden die Spalten sonst kleiner beim Laden
+			if (OSUtil.isMac()) {
+				width += Math.round(width / 3.03);
+			}
+
+			// Teilweise werden die Breiten viel zu groß. Deshalb auf 3000 beschränken (siehe auch #1471)
+			if (width > 3000) {
+				width = 3000;
+			}
+
 			if (width < 0) {
 				continue;
 			}
 
-			if (OSUtil.isMac()) {
-				// Unter Mac werden die Spalten sonst kleiner beim Laden
-				width += Math.round(width / 3.03);
-			}
 			bodyLayerStack.getBodyDataLayer().setColumnWidthByPosition(position, width);
 		}
 


### PR DESCRIPTION
zu #1470


Ausschnitt aus "Wiederherstell-Datei" von @weber-r:
```
xvcorWorkingTimeIndex2.LAST_STATE.index.groupby=1;5;
xvcorWorkingTimeIndex2.LAST_STATE.index.hidden=[]
xvcorWorkingTimeIndex2.LAST_STATE.index.size=1,10598;6,3686;7,3686;2,5904;3,4617;11,14052;4,6560;10,54990;5,2147483647;8,2147483647;9,2147483647;0,2147483647;12,2147483647;13,2147483647;14,2147483647;
xvcorWorkingTimeIndex2.LAST_STATE.index.sortby=5,ASC;
xvcorWorkingTimeIndex2.LAST_STATE.search.hidden=[]
xvcorWorkingTimeIndex2.LAST_STATE.search.size=0,2147483647;1,2147483647;2,2147483647;3,2147483647;4,2147483647;5,2147483647;6,2147483647;7,2147483647;8,2147483647;9,2147483647;10,2147483647;11,2147483647;12,2147483647;13,2147483647;14,2147483647;15,2147483647;
xvcorWorkingTimeIndex2.LAST_STATE.table={\n  "name"\: "xvcorWorkingTimeIndex2",\n  "columns"\: [\n    {\n      "name"\: "\\u0026",\n      "type"\: "BOOLEAN",\n      "outputType"\: "OUTPUT",\n      "label"\: "\\u0026",\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "KeyLong",\n      "type"\: "INTEGER",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.KeyLong",\n      "decimals"\: 0,\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: true\n    },\n    {\n      "name"\: "EmployeeText",\n      "type"\: "STRING",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.EmployeeText",\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "CustomerText",\n      "type"\: "STRING",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.CustomerText",\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "ProjectText",\n      "type"\: "STRING",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.ProjectText",\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "ServiceText",\n      "type"\: "STRING",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.ServiceText",\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "BookingDate",\n      "type"\: "INSTANT",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.BookingDate",\n      "dateTimeType"\: "DATE",\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "StartDate",\n      "type"\: "INSTANT",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.StartDate",\n      "dateTimeType"\: "TIME",\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "EndDate",\n      "type"\: "INSTANT",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.EndDate",\n      "dateTimeType"\: "TIME",\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "RenderedQuantity",\n      "type"\: "DOUBLE",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.RenderedQuantity",\n      "decimals"\: 2,\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "ChargedQuantity",\n      "type"\: "DOUBLE",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.ChargedQuantity",\n      "decimals"\: 2,\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "Description",\n      "type"\: "STRING",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.Description",\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "ServiceContractText",\n      "type"\: "STRING",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.ServiceContractText",\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "Assigned",\n      "type"\: "BOOLEAN",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.Assigned",\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "LastDate",\n      "type"\: "INSTANT",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.LastDate",\n      "dateTimeType"\: "DATETIME",\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    },\n    {\n      "name"\: "InvoiceText",\n      "type"\: "STRING",\n      "outputType"\: "OUTPUT",\n      "label"\: "@WorkingTime.InvoiceText",\n      "readOnly"\: false,\n      "required"\: false,\n      "isLookup"\: false,\n      "visible"\: true,\n      "key"\: false\n    }\n  ],\n  "rows"\: [\n    {\n      "values"\: [\n        "b-true",\n        null,\n        "f-~-s-weberr%\\u0001weberr",\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null\n      ]\n    },\n    {\n      "values"\: [\n        "b-true",\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null\n      ]\n    },\n    {\n      "values"\: [\n        "b-false",\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null,\n        null\n      ]\n    }\n  ]\n}
```

Die Breite der Spalten der Nattables wurden teilweise mit 2147483647 persistiert (Maximaler Wert eines Integers).
Beim Persistieren tritt also wahrscheinlich ein Fehler auf. 
Dieser ist leider nicht mehr nachzuvollziehen.
Die Nattables kommen mit dieser Breite offensichtlich nicht zurecht.

Um dem Fehler trotzdem entgegenzuwirken, führen wir eine maximale Breite ein, mit der die Nattable-Spalten wiederhergestellt werden.
Damit bleibt die Anwendung nutzbar, die Spaltenbreite kann dann wieder angepasst werden und wird beim nächsten Neustart (hoffentlich) korrekt wiederhergestellt.


Ich denke mehr als Breite 3000  sollte in aller Regel nicht vorkommen:
![Bildschirmfoto 2023-04-17 um 13 18 56](https://user-images.githubusercontent.com/77741125/232469580-8cd2b9bb-acbd-4b44-b829-88357a9e0b87.png)

