### PR TITLE
Fehler beim Laden von Grids ausbessern

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,9 @@ Der entsprechende Abschnitt des Changelogs wird auch jeweils in die [Releasenote
 - Lookups die Möglichkeit geben, die Einträge über einen Helper zu sortieren 
 - Unter Linux den Spashscreen schließen, sobald Login-Dialog öffnet, damit Dialog nicht vom Splash überdeckt wird
 
+### Bugfixes
+- Fehler beim Laden von Grids ausbessern, hat Grids betroffen, die in der xbs eine Verknüpfung zu einem nicht-primary-key Feld enthalten haben
+
 ## [12.9.4] - 04.05.2023
 
 ### Änderung

--- a/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/WFCDetailCASRequestsUtil.java
+++ b/bundles/aero.minova.rcp.rcp/src/aero/minova/rcp/rcp/util/WFCDetailCASRequestsUtil.java
@@ -955,14 +955,9 @@ public class WFCDetailCASRequestsUtil {
 	@Optional
 	public void reloadFields(@UIEventTopic(Constants.BROKER_RELOADFIELDS) Table keyTable) {
 		if (isActivePerspective()) {
-			if (keyTable == null && keys != null) {
-				keyTable = new Table();
-				Row r = new Row();
-				for (Entry<String, Value> e : keys.entrySet()) {
-					keyTable.addColumn(new Column(e.getKey(), e.getValue().getType()));
-					r.addValue(e.getValue());
-				}
-				keyTable.addRow(r);
+			if (keyTable == null) {
+				// Sind keine keys gegeben aktuellen Stand aus dem Detail nutzen
+				keyTable = selectedTable;
 			}
 			readData(keyTable, false); // Nach Speichern soll discard-Nachricht nicht angezeigt werden
 		}


### PR DESCRIPTION
Fehler hat Grids betroffen, die in der xbs eine Verknüpfung zu einem nicht-primary-key Feld enthalten haben

closes https://github.com/minova-afis/aero.minova.sam.scharr/issues/74