### PR TITLE
Verhindern, dass alle Profile auf einmal gelöscht werden können

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,9 @@ Der entsprechende Abschnitt des Changelogs wird auch jeweils in die [Releasenote
 
 ## [Unreleased]
 
+### Bugfixes
+- Verhindern, dass alle Profile auf einmal gelöscht werden können
+
 ## [12.9.6] - 07.06.2023
 
 ### Änderung

--- a/bundles/aero.minova.rcp.preferences/src/aero/minova/rcp/preferences/WorkspaceAccessPreferences.java
+++ b/bundles/aero.minova.rcp.preferences/src/aero/minova/rcp/preferences/WorkspaceAccessPreferences.java
@@ -66,6 +66,12 @@ public class WorkspaceAccessPreferences {
 				.node(WORKSPACES);
 		if (workspaces.nodeExists(name)) {
 			ISecurePreferences node = workspaces.node(name);
+
+			if (node.childrenNames().length > 0) {
+				logger.error("Node \"" + name + "\" has Children, not deleting");
+				return;
+			}
+
 			node.clear();
 			node.removeNode();
 			try {

--- a/bundles/aero.minova.rcp.workspace/src/aero/minova/rcp/workspace/dialogs/WorkspaceDialog.java
+++ b/bundles/aero.minova.rcp.workspace/src/aero/minova/rcp/workspace/dialogs/WorkspaceDialog.java
@@ -122,7 +122,15 @@ public class WorkspaceDialog extends Dialog {
 		deleteProfile.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseDown(MouseEvent e) {
-				WorkspaceAccessPreferences.deleteSavedWorkspace(profile.getText());
+
+				String profileNameToDelete = profile.getText();
+				logger.info("Deleting Profile \"" + profileNameToDelete + "\"");
+				if (profileNameToDelete == null || profileNameToDelete.isBlank()) {
+					logger.info("No profile selected, not deleting");
+					return;
+				}
+
+				WorkspaceAccessPreferences.deleteSavedWorkspace(profileNameToDelete);
 				try {
 					// Workspace Ordner löschen
 					FileUtils.deleteDirectory(new File(applicationArea.getText().replace("file:", "")));


### PR DESCRIPTION
closes #1508

- Wenn kein Profil ausgewählt ist, dann nichts löschen
- Wenn die zu löschende Node selbst Kinder hat, nichts tun, damit nur die "untersten", also die wirklichen Workspaces, entfernt werden können

Außerdem Logging einbauen