### PR TITLE
Bei Lookup-Tabellenanfragen LastAction als Integer schicken

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,9 @@ Der entsprechende Abschnitt des Changelogs wird auch jeweils in die [Releasenote
 
 ## [Unreleased]
 
+### Bugfixes
+- Bei Lookups mit Tabellen/Views die LastAction als Integer schicken. Wichtig für Postgres-Datenbanken, da hier der Dateityp genau passen muss.
+
 ## [12.9.6] - 07.06.2023
 
 ### Änderung

--- a/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
+++ b/bundles/aero.minova.rcp.dataservice/src/aero/minova/rcp/dataservice/internal/DataService.java
@@ -97,7 +97,7 @@ public class DataService implements IDataService {
 	private int minTimeBetweenError = 3;
 	Map<String, Long> timeOfLastErrorMessage = new HashMap<>();
 
-	private static final FilterValue fv = new FilterValue(">", "0", "");
+	private static final FilterValue fv = new FilterValue(">", 0, "");
 
 	private static final boolean LOG_CACHE = "true".equalsIgnoreCase(Platform.getDebugOption("aero.minova.rcp.dataservice/debug/cache"));
 	private static final boolean LOG_SQL_STRING = "true".equalsIgnoreCase(Platform.getDebugOption("aero.minova.rcp.dataservice/debug/logsqlstring"));


### PR DESCRIPTION
Ist wichtig für Postgres-Datenbanken, da hier der Dateityp genau passen muss.