### PR TITLE
Wieder eigenen Dialog anzeigen, wenn mit ungespeicherten Änderungen versucht wird zu speichern

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,8 @@ Der entsprechende Abschnitt des Changelogs wird auch jeweils in die [Releasenote
 
 ### Bugfixes
 - Grid korrekt aufbauen, auch wenn keine Statistik in der XBS konfiguriert ist
+- Wieder eigenen Dialog anzeigen, wenn mit ungespeicherten Änderungen versucht wird zu speichern
+
 
 ## [12.16.0] - 08.10.2025
 

--- a/bundles/aero.minova.rcp.rcp/fragment.e4xmi
+++ b/bundles/aero.minova.rcp.rcp/fragment.e4xmi
@@ -419,6 +419,6 @@
     <elements xsi:type="application:Addon" xmi:id="_Lx0fYCEvEeyLzPNotbg_ew" elementId="aero.minova.rcp.rcp.addon.iconrendering" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.addons.IconRendering"/>
     <elements xsi:type="application:Addon" xmi:id="_LiQbIPYfEeyxFrZzmcAvXw" elementId="aero.minova.rcp.rcp.addon.notificationanderroraddon" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.addons.NotificationAndErrorAddon"/>
     <elements xsi:type="application:Addon" xmi:id="_jr1uYPbcEeyxFrZzmcAvXw" elementId="aero.minova.rcp.rcp.addon.windowcloselisteneraddon" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.addons.WindowCloseListenerAddon"/>
-    <elements xsi:type="application:Addon" xmi:id="_RIEmwCMIEe-NeP13ZPgZLw" elementId="aero.minova.rcp.rcp.addon.windowcloselisteneraddon" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.addons.WindowLabelAddon"/>
+    <elements xsi:type="application:Addon" xmi:id="_RIEmwCMIEe-NeP13ZPgZLw" elementId="aero.minova.rcp.rcp.addon.windowlabeladdon" contributionURI="bundleclass://aero.minova.rcp.rcp/aero.minova.rcp.rcp.addons.WindowLabelAddon"/>
   </fragments>
 </fragment:ModelFragments>


### PR DESCRIPTION
closes https://github.com/minova-afis/aero.minova.rcp/issues/1648